### PR TITLE
fix: hero address, service card limit, review count

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -34,12 +34,11 @@ const isVideo = heroVideo && /\.(mp4|webm)$/i.test(heroVideo);
       <div class="open-badge" id="open-badge">
         <span class="badge-text">Loading hours...</span>
       </div>
-      {location?.address && (
-        <p class="hero-address">
-          <a href={location.mapLink || '#'}>
-            {'\u{1F4CD} ' + location.address + ', ' + (location.city || '')}{location.state ? ` ${location.state}` : ''}{location.zip ? ` ${location.zip}` : ''}
-          </a>
-        </p>
+      {location?.city && (
+        <a href={location.mapLink || '#'} class="hero-location">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+          <span>{location.city}{location.state ? `, ${location.state}` : ''}{location.zip ? ` ${location.zip}` : ''}</span>
+        </a>
       )}
       <a href={heroCta.href || '#'} class="btn-primary">{heroCta.text || 'Learn More'}</a>
     </div>

--- a/src/components/ServiceCards.astro
+++ b/src/components/ServiceCards.astro
@@ -10,9 +10,9 @@ const services = Object.values(serviceFiles)
   .map((mod: any) => mod.frontmatter)
   .sort((a: any, b: any) => (a.order || 0) - (b.order || 0));
 
-const MAX_FEATURED = 3;
+const MAX_FEATURED = 6;
 const featured = services.filter((s: any) => s.beforeImage).slice(0, MAX_FEATURED);
-const secondary = services.slice(featured.length);
+const secondary = services.filter((s: any) => !featured.includes(s));
 ---
 {services.length > 0 && (
   <section class="services-section section" data-variant={variant} id="services">

--- a/src/components/TrustBadges.astro
+++ b/src/components/TrustBadges.astro
@@ -8,10 +8,12 @@ const foundingYear = parseInt((client as any).foundingYear || '0', 10);
 const yearsInBusiness = foundingYear > 1900 ? currentYear - foundingYear : 0;
 
 const reviews = testimonials?.items || [];
-const reviewCount = reviews.length;
-const avgRating = reviewCount > 0
-  ? (reviews.reduce((sum: number, r: any) => sum + (r.rating || 0), 0) / reviewCount).toFixed(1)
-  : '0';
+const reviewCount = (testimonials as any)?.totalReviewCount || reviews.length;
+const avgRating = (testimonials as any)?.averageRating
+  ? String((testimonials as any).averageRating)
+  : reviews.length > 0
+    ? (reviews.reduce((sum: number, r: any) => sum + (r.rating || 0), 0) / reviews.length).toFixed(1)
+    : '0';
 const hasRating = reviewCount > 0 && parseFloat(avgRating) > 0;
 
 const license = (client as any).license || '';

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -51,11 +51,17 @@
   50% { opacity: 0.4; transform: scale(0.8); }
 }
 
-.hero-address {
+.hero-location {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   font-size: var(--font-size-small);
-  opacity: 0.8;
+  opacity: 0.7;
+  text-decoration: none;
+  color: inherit;
+  margin-top: 0.5rem;
 }
-.hero-address a { color: var(--text); text-decoration: underline; }
+.hero-location:hover { opacity: 1; }
 .hero .btn-primary { width: fit-content; max-width: 280px; text-align: center; }
 
 .hero-photo {


### PR DESCRIPTION
## Summary
- Hero: modernize address display (SVG icon + city/state only, no emoji + full street address)
- ServiceCards: show up to 6 featured cards instead of 3
- TrustBadges: use `totalReviewCount` and `averageRating` from testimonials.json when available

## Context
Discovered while building PW Tint site with template. The hero address looked dated, services capped at 3 cards, review count showed carousel items instead of actual total.

## Test plan
- [ ] Build with existing data (Martinez Welding) - no regression
- [ ] Build with PW Tint data (6 services, 28 reviews) - all cards show, correct count

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Redesigned location display with a new icon style and improved text formatting for better readability.
  * Featured services section now showcases 6 items instead of 3, giving more visibility to top offerings.
  * Review and rating information now uses aggregate testimonial data for more accurate representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->