### PR TITLE
fix: CSS selector bug, section centering, nav CTA contrast

### DIFF
--- a/src/lib/brand.ts
+++ b/src/lib/brand.ts
@@ -106,7 +106,7 @@ export function generateLayoutCSS(layout?: Record<string, string>): string {
     vars.push(`  --font-size-h2: ${scale.h2};`);
   }
 
-  return vars.length > 0 ? `html:root {\n${vars.join('\n')}\n}` : '';
+  return vars.length > 0 ? `:root {\n${vars.join('\n')}\n}` : '';
 }
 
 /**

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -96,10 +96,15 @@ body {
 .nav-cta {
   display: inline-block;
   padding: 0.5rem 1.25rem;
-  background: var(--accent);
+  background: var(--primary);
   color: var(--background);
-  border-radius: var(--card-radius);
+  border-radius: var(--btn-radius, var(--card-radius));
   font-weight: 600;
+  text-decoration: none;
+  transition: opacity var(--transition-fast);
+}
+.nav-cta:hover {
+  opacity: 0.9;
   text-decoration: none;
 }
 

--- a/src/styles/projects.css
+++ b/src/styles/projects.css
@@ -7,6 +7,8 @@
 .projects-grid {
   display: grid;
   gap: 2rem;
+  max-width: 960px;
+  margin-inline: auto;
 }
 
 /* --- Slider --- */

--- a/src/styles/services.css
+++ b/src/styles/services.css
@@ -8,10 +8,10 @@
   gap: 1.5rem;
 }
 @media (min-width: 768px) {
-  .services-grid { grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); }
-  .services-grid:has(> :last-child:nth-child(1)),
-  .services-grid:has(> :last-child:nth-child(2)) {
-    max-width: 700px;
+  .services-grid {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    justify-items: center;
+    max-width: 960px;
     margin-inline: auto;
   }
 }
@@ -89,8 +89,10 @@
 /* ── Variant: icon-grid ─────────────────────────────────────────────── */
 .services-icon-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 1.25rem;
+  max-width: 960px;
+  margin-inline: auto;
 }
 
 .service-icon-card {


### PR DESCRIPTION
## Summary
- **Critical fix**: `html:root` → `:root` in `generateLayoutCSS()` — this typo prevented ALL layout token CSS variables (card-radius, section-gap, btn-radius, img-radius, typography scale) from being applied. Every site build since layout tokens were added has been affected.
- **Services/icon-grid centering**: `auto-fill` → `auto-fit` with `max-width: 960px; margin-inline: auto` so cards center properly instead of left-aligning when fewer than grid columns
- **Projects grid centering**: Added `max-width: 960px; margin-inline: auto`
- **Nav CTA button**: Changed from `var(--accent)` to `var(--primary)` background for better dark mode contrast. Added `var(--btn-radius)` for layout token support and hover state.

## Why
These issues were recurring in every build (Good Times, Showtime Auto Detail, etc.) and were being "fixed" per-build instead of at the source. Root cause analysis showed they were all template-level bugs.

## Test plan
- [ ] Rebuild Showtime Auto Detail with updated template — verify layout tokens apply
- [ ] Verify services grid centers with 3 and 5 cards
- [ ] Verify nav CTA is readable in dark mode
- [ ] Verify projects section centers with 1 item

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Navigation button styling updated with new color scheme and smooth hover transitions
  * Projects and services sections now feature improved centered layouts with optimized width constraints
  * Responsive grid layouts refined for better visual consistency across screen sizes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->