### PR TITLE
fix: gate alert banner on startDate/endDate (#95)

### DIFF
--- a/src/__tests__/alert-dates.test.ts
+++ b/src/__tests__/alert-dates.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+/**
+ * Tests the alert banner date-gating logic from BaseLayout.astro.
+ * The logic: if startDate is set and in the future, hide.
+ * If endDate is set and in the past, hide. No dates = show (backwards compat).
+ */
+
+interface AlertData {
+  enabled: boolean;
+  text: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+/** Mirrors the alertVisible logic in BaseLayout.astro */
+function isAlertVisible(alert: AlertData, now: Date): boolean {
+  if (!alert?.enabled || !alert?.text) return false;
+  const today = now.toISOString().slice(0, 10); // YYYY-MM-DD
+  if (alert.startDate && today < alert.startDate) return false;
+  if (alert.endDate && today > alert.endDate) return false;
+  return true;
+}
+
+describe('alert banner date gating', () => {
+  it('shows alert when enabled with text and no dates', () => {
+    expect(isAlertVisible({ enabled: true, text: 'Hello' }, new Date('2026-03-28'))).toBe(true);
+  });
+
+  it('hides alert when disabled', () => {
+    expect(isAlertVisible({ enabled: false, text: 'Hello' }, new Date('2026-03-28'))).toBe(false);
+  });
+
+  it('hides alert when text is empty', () => {
+    expect(isAlertVisible({ enabled: true, text: '' }, new Date('2026-03-28'))).toBe(false);
+  });
+
+  it('hides alert before startDate', () => {
+    expect(isAlertVisible(
+      { enabled: true, text: 'Sale!', startDate: '2026-04-01' },
+      new Date('2026-03-28')
+    )).toBe(false);
+  });
+
+  it('shows alert on startDate', () => {
+    expect(isAlertVisible(
+      { enabled: true, text: 'Sale!', startDate: '2026-03-28' },
+      new Date('2026-03-28')
+    )).toBe(true);
+  });
+
+  it('shows alert after startDate', () => {
+    expect(isAlertVisible(
+      { enabled: true, text: 'Sale!', startDate: '2026-03-01' },
+      new Date('2026-03-28')
+    )).toBe(true);
+  });
+
+  it('hides alert after endDate', () => {
+    expect(isAlertVisible(
+      { enabled: true, text: 'Sale!', endDate: '2026-03-27' },
+      new Date('2026-03-28')
+    )).toBe(false);
+  });
+
+  it('shows alert on endDate', () => {
+    expect(isAlertVisible(
+      { enabled: true, text: 'Sale!', endDate: '2026-03-28' },
+      new Date('2026-03-28')
+    )).toBe(true);
+  });
+
+  it('shows alert before endDate', () => {
+    expect(isAlertVisible(
+      { enabled: true, text: 'Sale!', endDate: '2026-04-15' },
+      new Date('2026-03-28')
+    )).toBe(true);
+  });
+
+  it('shows alert within startDate-endDate window', () => {
+    expect(isAlertVisible(
+      { enabled: true, text: 'Sale!', startDate: '2026-03-01', endDate: '2026-04-01' },
+      new Date('2026-03-28')
+    )).toBe(true);
+  });
+
+  it('hides alert before startDate even with future endDate', () => {
+    expect(isAlertVisible(
+      { enabled: true, text: 'Sale!', startDate: '2026-04-01', endDate: '2026-04-15' },
+      new Date('2026-03-28')
+    )).toBe(false);
+  });
+
+  it('hides alert after endDate even with past startDate', () => {
+    expect(isAlertVisible(
+      { enabled: true, text: 'Sale!', startDate: '2026-03-01', endDate: '2026-03-15' },
+      new Date('2026-03-28')
+    )).toBe(false);
+  });
+
+  it('handles missing startDate with endDate set', () => {
+    expect(isAlertVisible(
+      { enabled: true, text: 'Sale!', endDate: '2026-04-01' },
+      new Date('2026-03-28')
+    )).toBe(true);
+  });
+
+  it('handles missing endDate with startDate set', () => {
+    expect(isAlertVisible(
+      { enabled: true, text: 'Sale!', startDate: '2026-03-01' },
+      new Date('2026-03-28')
+    )).toBe(true);
+  });
+});

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -40,6 +40,15 @@ const hoursJson = JSON.stringify(hours);
 const hasGallery = gallery?.images?.length > 0;
 const hasProjects = (projects as any)?.projects?.length > 0;
 
+// Alert banner date gating — hide if outside startDate/endDate window
+const alertVisible = (() => {
+  if (!alert?.enabled || !alert?.text) return false;
+  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  if ((alert as any).startDate && today < (alert as any).startDate) return false;
+  if ((alert as any).endDate && today > (alert as any).endDate) return false;
+  return true;
+})();
+
 // Preload hero image for LCP optimization
 const heroImage = (hero as any)?.heroImage;
 const heroResolved = heroImage ? resolveImage(heroImage) : null;
@@ -96,7 +105,7 @@ const depth = layout.depth || '';
     <div class="noise-overlay" aria-hidden="true"></div>
   )}
 
-  {alert && alert.enabled && alert.text && (
+  {alertVisible && (
     <div class="alert-banner">{alert.text}</div>
   )}
 


### PR DESCRIPTION
## Summary
- Adds build-time date gating to the alert banner in `BaseLayout.astro`
- If `startDate` is set and today is before it, the banner is hidden
- If `endDate` is set and today is past it, the banner is hidden
- No dates set = banner shows when enabled (backwards compatible with existing `alert.json` files)
- Build-time check is sufficient because client sites rebuild on every CMS change via CF Pages

## Changes
- `src/layouts/BaseLayout.astro`: Extracted alert visibility into `alertVisible` computed variable with date comparison logic
- `src/__tests__/alert-dates.test.ts`: 14 unit tests covering all date combinations (no dates, start only, end only, both, boundary dates)

## Test plan
- [x] All 31 tests pass (14 new alert date tests + 17 existing)
- [ ] Visual verification: set `startDate` to future date, confirm banner hidden
- [ ] Visual verification: set `endDate` to past date, confirm banner hidden
- [ ] Visual verification: no dates + enabled = banner visible

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Alert banners can now be scheduled to display only within specified date ranges using configurable start and end dates.

* **Tests**
  * Added comprehensive test suite to validate alert banner date-gating behavior across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->