### PR TITLE
refactor: extract alert visibility to shared util (#28, #29)

### DIFF
--- a/src/__tests__/alert-dates.test.ts
+++ b/src/__tests__/alert-dates.test.ts
@@ -1,26 +1,11 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
+import { isAlertVisible } from '../lib/alert';
 
 /**
- * Tests the alert banner date-gating logic from BaseLayout.astro.
+ * Tests the alert banner date-gating logic extracted to src/lib/alert.ts.
  * The logic: if startDate is set and in the future, hide.
  * If endDate is set and in the past, hide. No dates = show (backwards compat).
  */
-
-interface AlertData {
-  enabled: boolean;
-  text: string;
-  startDate?: string;
-  endDate?: string;
-}
-
-/** Mirrors the alertVisible logic in BaseLayout.astro */
-function isAlertVisible(alert: AlertData, now: Date): boolean {
-  if (!alert?.enabled || !alert?.text) return false;
-  const today = now.toISOString().slice(0, 10); // YYYY-MM-DD
-  if (alert.startDate && today < alert.startDate) return false;
-  if (alert.endDate && today > alert.endDate) return false;
-  return true;
-}
 
 describe('alert banner date gating', () => {
   it('shows alert when enabled with text and no dates', () => {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,6 +13,8 @@ import hero from '../data/hero.json';
 import { generateThemeCSS, generateLayoutCSS } from '../lib/brand';
 import { buildFontFaceCSS } from '../lib/fonts';
 import { resolveImage } from '../lib/images';
+import { isAlertVisible } from '../lib/alert';
+import type { AlertData } from '../lib/alert';
 import type { Brand, Theme } from '../lib/types';
 // v4 CSS architecture
 import '../styles/tokens.css';
@@ -41,13 +43,7 @@ const hasGallery = gallery?.images?.length > 0;
 const hasProjects = (projects as any)?.projects?.length > 0;
 
 // Alert banner date gating — hide if outside startDate/endDate window
-const alertVisible = (() => {
-  if (!alert?.enabled || !alert?.text) return false;
-  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-  if ((alert as any).startDate && today < (alert as any).startDate) return false;
-  if ((alert as any).endDate && today > (alert as any).endDate) return false;
-  return true;
-})();
+const alertVisible = isAlertVisible(alert as AlertData);
 
 // Preload hero image for LCP optimization
 const heroImage = (hero as any)?.heroImage;

--- a/src/lib/alert.ts
+++ b/src/lib/alert.ts
@@ -1,0 +1,15 @@
+export interface AlertData {
+  enabled: boolean;
+  text: string;
+  startDate?: string; // YYYY-MM-DD
+  endDate?: string; // YYYY-MM-DD
+}
+
+/** Check if an alert should be visible based on enabled state and date window. */
+export function isAlertVisible(alert: AlertData, now?: Date): boolean {
+  if (!alert?.enabled || !alert?.text) return false;
+  const today = (now ?? new Date()).toISOString().slice(0, 10);
+  if (alert.startDate && today < alert.startDate) return false;
+  if (alert.endDate && today > alert.endDate) return false;
+  return true;
+}


### PR DESCRIPTION
## Summary
- Created `src/lib/alert.ts` with `AlertData` interface and `isAlertVisible()` function
- Updated `BaseLayout.astro` to import the shared util instead of inlining an IIFE with `as any` casts
- Updated `src/__tests__/alert-dates.test.ts` to import from the shared module instead of maintaining a duplicate copy

All 14 alert date-gating test cases preserved and passing (31 total tests across 5 files).

Closes #28, closes #29.

## Test plan
- [x] All 14 alert date-gating tests pass via `npx vitest run`
- [x] No other test regressions (31/31 pass)
- [x] BaseLayout.astro uses typed `AlertData` import instead of `as any` casts


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated alert visibility logic into a shared utility for improved code maintainability. Alert banner functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->