### PR TITLE
feat: Behold Instagram gallery, products section, team support

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -231,6 +231,11 @@ content:
     path: src/data/gallery.json
     format: json
     fields:
+      - name: beholdFeedId
+        label: Instagram Feed ID
+        type: string
+        required: false
+        description: "Behold.so feed ID for a live Instagram feed. Leave blank to show static photos only."
       - name: images
         label: Photos
         type: object
@@ -394,3 +399,80 @@ content:
         type: number
         default: 1
         description: "Lower numbers appear first (1 = first card). Maximum 6 services total."
+
+  # ── Products (Pricing + Specs) ─────────────────────────────────────────────
+  - name: products
+    label: Products
+    type: collection
+    path: src/content/products
+    extension: md
+    format: yaml-frontmatter
+    filename: "{order}-{fields.name | slugify}"
+    media:
+      input: src/assets/images/products
+      output: /assets/images/products
+    view:
+      primary: name
+      fields: [name, subtitle]
+      sort: [order]
+      default:
+        sort: order
+        order: asc
+    fields:
+      - name: name
+        label: Product Name
+        type: string
+      - name: subtitle
+        label: Subtitle
+        type: string
+        required: false
+        description: "Size, capacity, or tier label. Example: 20 Cubic Yards"
+      - name: detail
+        label: Detail Line
+        type: string
+        required: false
+        description: "Dimensions or specs summary. Example: 22' L x 7.5' W x 4.5' H"
+      - name: badge
+        label: Badge Text
+        type: string
+        required: false
+        description: "Secondary label shown next to the name."
+      - name: image
+        label: Image
+        type: image
+      - name: featured
+        label: Featured
+        type: boolean
+        default: false
+        description: "Featured products get accent styling and a 'Most Popular' badge."
+      - name: order
+        label: Display Order
+        type: number
+        default: 1
+        description: "Lower numbers appear first."
+      - name: tags
+        label: Tags
+        type: string
+        list: true
+        required: false
+        description: "Tag pills shown below pricing. Example: Garage cleanouts"
+      - name: pricing
+        label: Pricing Tiers
+        type: object
+        required: false
+        list:
+          collapsible:
+            summary: "{{label}} — ${{price}}"
+        fields:
+          - name: label
+            label: Label
+            type: string
+            description: "Duration or tier name. Example: 1-3 Days"
+          - name: price
+            label: Price
+            type: number
+          - name: note
+            label: Note
+            type: string
+            required: false
+            description: "Short description of this tier."

--- a/src/components/PhotoGallery.astro
+++ b/src/components/PhotoGallery.astro
@@ -1,50 +1,129 @@
 ---
 // src/components/PhotoGallery.astro
-// DCD Luxury gallery — 12-column masonry grid with hover overlays,
-// 3D tilt on desktop, lightbox on click, staggered entrance
+// Gallery with optional Behold Instagram feed + static photo fallback.
+// Variants: masonry (default), scroll (horizontal scroll row).
+// If beholdFeedId is set in gallery.json, loads the live Instagram widget.
+// Falls back to the static grid if Behold fails or no feed ID configured.
 import galleryRaw from '../data/gallery.json';
 const gallery = galleryRaw as any;
 import OptimizedImg from './OptimizedImg.astro';
 
+interface Props { variant?: string | number; }
+const { variant: variantProp } = Astro.props;
+const variant = String(variantProp || 'masonry');
+
 const images = gallery?.images || gallery?.items || [];
 const hasGallery = images.length > 0;
+const beholdFeedId = gallery?.beholdFeedId || '';
 ---
 
-{hasGallery && (
+{(hasGallery || beholdFeedId) && (
   <section class="gallery-section section" id="gallery">
     <div class="container">
       <h2 class="section-heading">Photos</h2>
     </div>
 
-    <div class="gallery-grid stagger-parent container">
-      {images.map((img: any, i: number) => (
-        <button
-          class={`gallery-item gallery-thumb ${i % 4 < 2 ? 'gallery-item--wide' : 'gallery-item--narrow'}`}
-          data-tilt="3"
-          data-index={i}
-          type="button"
-          aria-label={`View ${img.alt || `photo ${i + 1}`}`}
-        >
-          <OptimizedImg
-            src={img.url || img.image}
-            alt={img.alt || ''}
-            width={800}
-            height={600}
-            fallback={img.fallbackUrl || img.fallback || ''}
-            class="gallery-img"
-          />
-          <div class="gallery-overlay">
-            <span class="gallery-caption">{img.alt || ''}</span>
-            <svg class="gallery-zoom-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="11" cy="11" r="8"/>
-              <line x1="21" y1="21" x2="16.65" y2="16.65"/>
-              <line x1="11" y1="8" x2="11" y2="14"/>
-              <line x1="8" y1="11" x2="14" y2="11"/>
-            </svg>
-          </div>
-        </button>
-      ))}
-    </div>
+    {/* ── Behold Instagram widget ──────────────────────────────────── */}
+    {beholdFeedId && (
+      <div class="behold-wrap container" id="gallery-behold">
+        <behold-widget feed-id={beholdFeedId}></behold-widget>
+      </div>
+    )}
+
+    {/* ── Horizontal scroll variant ─────────────────────────────────── */}
+    {variant === 'scroll' && hasGallery && (
+      <div class="gallery-scroll container" id="gallery-static">
+        {images.map((img: any, i: number) => (
+          <button
+            class="gallery-scroll-item gallery-thumb"
+            data-index={i}
+            type="button"
+            aria-label={`View ${img.alt || `photo ${i + 1}`}`}
+          >
+            <OptimizedImg
+              src={img.url || img.image}
+              alt={img.alt || ''}
+              width={600}
+              height={400}
+              fallback={img.fallbackUrl || img.fallback || ''}
+              class="gallery-img"
+            />
+            <div class="gallery-overlay">
+              <span class="gallery-caption">{img.alt || ''}</span>
+              <svg class="gallery-zoom-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="11" cy="11" r="8"/>
+                <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                <line x1="11" y1="8" x2="11" y2="14"/>
+                <line x1="8" y1="11" x2="14" y2="11"/>
+              </svg>
+            </div>
+          </button>
+        ))}
+      </div>
+    )}
+
+    {/* ── Static masonry grid (fallback when Behold active, primary otherwise) */}
+    {variant !== 'scroll' && hasGallery && (
+      <div
+        class="gallery-grid stagger-parent container"
+        id={variant === 'scroll' ? undefined : 'gallery-static'}
+        style={beholdFeedId ? 'display:none' : undefined}
+      >
+        {images.map((img: any, i: number) => (
+          <button
+            class={`gallery-item gallery-thumb ${i % 4 < 2 ? 'gallery-item--wide' : 'gallery-item--narrow'}`}
+            data-tilt="3"
+            data-index={i}
+            type="button"
+            aria-label={`View ${img.alt || `photo ${i + 1}`}`}
+          >
+            <OptimizedImg
+              src={img.url || img.image}
+              alt={img.alt || ''}
+              width={800}
+              height={600}
+              fallback={img.fallbackUrl || img.fallback || ''}
+              class="gallery-img"
+            />
+            <div class="gallery-overlay">
+              <span class="gallery-caption">{img.alt || ''}</span>
+              <svg class="gallery-zoom-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="11" cy="11" r="8"/>
+                <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                <line x1="11" y1="8" x2="11" y2="14"/>
+                <line x1="8" y1="11" x2="14" y2="11"/>
+              </svg>
+            </div>
+          </button>
+        ))}
+      </div>
+    )}
+
+    {/* ── Behold loader + fallback script ──────────────────────────── */}
+    {beholdFeedId && (
+      <script is:inline>
+        (function() {
+          var s = document.createElement('script');
+          s.type = 'module';
+          s.src = 'https://w.behold.so/widget.js';
+          document.head.appendChild(s);
+
+          // If Behold hasn't rendered after 5s, show static fallback
+          setTimeout(function() {
+            var widget = document.querySelector('behold-widget');
+            var fallback = document.getElementById('gallery-static');
+            if (!widget || !fallback) return;
+            var shadow = widget.shadowRoot;
+            var rendered = shadow && shadow.children.length > 1;
+            if (!rendered) {
+              var wrap = document.getElementById('gallery-behold');
+              if (wrap) wrap.style.display = 'none';
+              fallback.style.removeProperty('display');
+            }
+          }, 5000);
+        })();
+      </script>
+    )}
 
     <!-- Lightbox markup (driven by gallery-lightbox.js) -->
     <div class="gallery-lightbox" id="gallery-lightbox" aria-hidden="true" role="dialog" aria-label="Image lightbox">
@@ -77,6 +156,78 @@ const hasGallery = images.length > 0;
   .gallery-section {
     padding: var(--section-pad, 4rem) 0;
     overflow: hidden;
+  }
+
+  /* ── Behold Instagram widget ───────────────────────────────────── */
+  .behold-wrap {
+    margin-bottom: 2rem;
+  }
+
+  /* ── Horizontal scroll variant ─────────────────────────────────── */
+  .gallery-scroll {
+    display: flex;
+    gap: var(--gap, 1rem);
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem;
+  }
+
+  .gallery-scroll-item {
+    flex: 0 0 auto;
+    width: min(400px, 75vw);
+    aspect-ratio: 3 / 2;
+    position: relative;
+    overflow: hidden;
+    border-radius: var(--card-radius, var(--radius-lg, 12px));
+    cursor: pointer;
+    border: 1px solid color-mix(in srgb, var(--accent) 10%, var(--border));
+    padding: 0;
+    background: var(--surface);
+    scroll-snap-align: start;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  }
+
+  .gallery-scroll-item :global(picture) {
+    display: contents;
+  }
+
+  .gallery-scroll-item :global(.gallery-img),
+  .gallery-scroll-item :global(img) {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    transition: transform 0.5s var(--ease-out-expo, cubic-bezier(0.16, 1, 0.3, 1));
+  }
+
+  .gallery-scroll-item:hover :global(.gallery-img),
+  .gallery-scroll-item:hover :global(img) {
+    transform: scale(1.05);
+  }
+
+  .gallery-scroll-item .gallery-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
+    padding: 1.5rem;
+    background: linear-gradient(to top, rgba(0,0,0,0.65) 0%, rgba(0,0,0,0.2) 40%, transparent 100%);
+    opacity: 0;
+    transition: opacity 0.35s ease;
+    pointer-events: none;
+  }
+
+  .gallery-scroll-item:hover .gallery-overlay,
+  .gallery-scroll-item:focus-visible .gallery-overlay {
+    opacity: 1;
+  }
+
+  .gallery-scroll-item:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
   }
 
   /* ── 12-column masonry grid ─────────────────────────────────────── */

--- a/src/components/Products.astro
+++ b/src/components/Products.astro
@@ -1,0 +1,285 @@
+---
+// src/components/Products.astro
+// Generic product cards with specs, tiered pricing, and tags.
+// Used for: dumpster fleets, tinting packages, equipment rentals, service tiers.
+import OptimizedImg from './OptimizedImg.astro';
+
+const productFiles = import.meta.glob('../content/products/*.md', { eager: true });
+const products = Object.values(productFiles)
+  .map((mod: any) => ({ ...mod.frontmatter, body: mod.compiledContent?.() || '' }))
+  .sort((a: any, b: any) => (a.order || 0) - (b.order || 0));
+
+const hasProducts = products.length > 0;
+---
+
+{hasProducts && (
+  <section class="products section" id="products">
+    <div class="container">
+      <div class="products__grid stagger-parent">
+        {products.map((product: any) => (
+          <div
+            class={`product-card card-luxury ${product.featured ? 'product-card--featured' : ''}`}
+            data-tilt="4"
+          >
+            {product.image && (
+              <div class="product-card__image-wrap">
+                <OptimizedImg
+                  src={product.image}
+                  alt={product.name || ''}
+                  width={800}
+                  height={500}
+                  class="product-card__image"
+                />
+                <div class="product-card__image-gradient"></div>
+                {product.featured && (
+                  <span class="product-card__popular">Most Popular</span>
+                )}
+              </div>
+            )}
+
+            <div class="product-card__body">
+              <div class="product-card__header">
+                <h3 class="h3">{product.name}</h3>
+                {product.badge && (
+                  <span class="product-card__badge">{product.badge}</span>
+                )}
+              </div>
+
+              {product.subtitle && (
+                <span class="product-card__subtitle">{product.subtitle}</span>
+              )}
+
+              {product.detail && (
+                <p class="product-card__detail">{product.detail}</p>
+              )}
+
+              {product.body && (
+                <p class="product-card__desc">{product.body}</p>
+              )}
+
+              {product.pricing?.length > 0 && (
+                <div class="product-card__pricing">
+                  {product.pricing.map((p: any) => (
+                    <div class="product-card__price-row">
+                      <div>
+                        <span class="product-card__price-label">{p.label}</span>
+                        {p.note && <span class="product-card__price-note">{p.note}</span>}
+                      </div>
+                      <span class="product-card__price-value">${p.price}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {product.tags?.length > 0 && (
+                <div class="product-card__tags-wrap">
+                  <div class="product-card__tags">
+                    {product.tags.map((tag: string) => (
+                      <span class="product-card__tag">{tag}</span>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+
+<style>
+  .products {
+    position: relative;
+    overflow: hidden;
+  }
+
+  /* ── Product grid ──────────────────────────────────────────────── */
+  .products__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 420px), 1fr));
+    gap: var(--gap-lg, 2rem);
+  }
+
+  /* ── Product card ──────────────────────────────────────────────── */
+  .product-card {
+    display: flex;
+    flex-direction: column;
+    border-radius: var(--radius-xl, 24px);
+    overflow: hidden;
+  }
+
+  .product-card--featured {
+    border-color: var(--border-glow);
+    box-shadow: 0 0 40px var(--accent-glow);
+  }
+
+  /* ── Image ─────────────────────────────────────────────────────── */
+  .product-card__image-wrap {
+    position: relative;
+    height: 300px;
+    overflow: hidden;
+  }
+
+  .product-card__image-wrap :global(picture) {
+    display: contents;
+  }
+
+  .product-card__image-wrap :global(.product-card__image),
+  .product-card__image-wrap :global(img) {
+    width: 100%;
+    height: 150%;
+    object-fit: cover;
+    object-position: center 100%;
+    transition: transform var(--duration-glacial, 0.8s) var(--ease-out-expo, cubic-bezier(0.16, 1, 0.3, 1));
+  }
+
+  .product-card:hover :global(.product-card__image),
+  .product-card:hover :global(img) {
+    transform: scale(1.06);
+  }
+
+  .product-card__image-gradient {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, transparent 40%, var(--surface, #111) 100%);
+  }
+
+  .product-card__popular {
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
+    background: var(--accent);
+    color: var(--bg, #050505);
+    font-family: var(--font-mono, monospace);
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    padding: 0.375rem 0.875rem;
+    border-radius: 100px;
+  }
+
+  /* ── Card body ─────────────────────────────────────────────────── */
+  .product-card__body {
+    padding: 1.75rem 2rem 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    flex: 1;
+  }
+
+  .product-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+
+  .product-card__badge {
+    font-family: var(--font-mono, monospace);
+    font-size: var(--mono-size, 0.75rem);
+    color: var(--text-muted, #888);
+  }
+
+  .product-card__subtitle {
+    font-family: var(--font-display, sans-serif);
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--accent);
+  }
+
+  .product-card__detail {
+    font-family: var(--font-mono, monospace);
+    font-size: var(--small-size, 0.8125rem);
+    color: var(--text-muted, #888);
+  }
+
+  .product-card__desc {
+    font-size: var(--small-size, 0.8125rem);
+    color: var(--text-secondary, #aaa);
+    line-height: 1.6;
+  }
+
+  /* ── Pricing table ─────────────────────────────────────────────── */
+  .product-card__pricing {
+    display: flex;
+    flex-direction: column;
+    margin-top: 0.5rem;
+    border-top: 1px solid var(--border-subtle, #222);
+  }
+
+  .product-card__price-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid var(--border-subtle, #222);
+  }
+
+  .product-card__price-row:last-child {
+    border-bottom: none;
+  }
+
+  .product-card__price-label {
+    font-family: var(--font-display, sans-serif);
+    font-size: 0.9375rem;
+    font-weight: 500;
+    color: var(--text, #eee);
+    display: block;
+  }
+
+  .product-card__price-note {
+    font-size: 0.75rem;
+    color: var(--text-muted, #888);
+    display: block;
+    margin-top: 2px;
+  }
+
+  .product-card__price-value {
+    font-family: var(--font-mono, monospace);
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--accent);
+    flex-shrink: 0;
+  }
+
+  /* ── Tags ───────────────────────────────────────────────────────── */
+  .product-card__tags-wrap {
+    margin-top: auto;
+    padding-top: 0.75rem;
+  }
+
+  .product-card__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+  }
+
+  .product-card__tag {
+    font-size: 0.75rem;
+    color: var(--text-secondary, #aaa);
+    background: var(--surface-glass, rgba(255, 255, 255, 0.04));
+    border: 1px solid var(--border-subtle, #222);
+    border-radius: 100px;
+    padding: 0.25rem 0.75rem;
+  }
+
+  /* ── Responsive ────────────────────────────────────────────────── */
+  @media (max-width: 768px) {
+    .products__grid {
+      grid-template-columns: 1fr;
+    }
+
+    .product-card__body {
+      padding: 1.5rem;
+    }
+  }
+
+  /* ── Reduced motion ────────────────────────────────────────────── */
+  @media (prefers-reduced-motion: reduce) {
+    .product-card__image-wrap :global(.product-card__image),
+    .product-card__image-wrap :global(img) {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -159,6 +159,7 @@ export interface GalleryImage {
 }
 
 export interface Gallery {
+  beholdFeedId?: string;
   images: GalleryImage[];
 }
 
@@ -195,4 +196,40 @@ export interface Project {
 
 export interface Projects {
   projects: Project[];
+}
+
+export interface ProductPricing {
+  label: string;
+  price: number;
+  note?: string;
+}
+
+export interface Product {
+  name: string;
+  subtitle?: string;
+  detail?: string;
+  badge?: string;
+  image?: string;
+  featured?: boolean;
+  order?: number;
+  specs?: Record<string, string>;
+  tags?: string[];
+  pricing?: ProductPricing[];
+}
+
+export interface TeamMember {
+  name: string;
+  brandName?: string;
+  title?: string;
+  bio?: string;
+  photo?: string;
+  bookingUrl?: string;
+  bookingLabel?: string;
+  hours?: string;
+  specialties?: string[];
+  order?: number;
+}
+
+export interface Team {
+  items: TeamMember[];
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,6 +24,8 @@ import FloatingCTA from '../components/FloatingCTA.astro';
 import Marquee from '../components/Marquee.astro';
 import BeforeAfter from '../components/BeforeAfter.astro';
 import Differentiator from '../components/Differentiator.astro';
+import Team from '../components/Team.astro';
+import Products from '../components/Products.astro';
 
 import client from '../data/client.json';
 import contact from '../data/contact.json';
@@ -37,6 +39,8 @@ interface SectionEntry {
 }
 
 const isRestaurant = (client.industry || '').toLowerCase().includes('restaurant');
+const industryLower = (client.industry || '').toLowerCase();
+const hasTeam = industryLower.includes('barber') || industryLower.includes('salon') || industryLower.includes('stylist') || industryLower.includes('tattoo');
 const hasReviews = testimonials?.items?.length > 0;
 
 // Resolve trust component from theme variant
@@ -60,6 +64,8 @@ const sectionMap: Record<string, any> = {
   beforeAfter: BeforeAfter,
   differentiator: Differentiator,
   marquee: Marquee,
+  team: Team,
+  products: Products,
 };
 
 // Use theme.json sectionOrder or fall back to defaults
@@ -95,6 +101,8 @@ const sectionLabels: Record<string, string> = {
   beforeAfter: '',    // not in nav
   differentiator: '', // not in nav
   marquee: '',        // not in nav
+  team: 'Team',
+  products: 'Products',
 };
 
 const navLinks = sections
@@ -102,10 +110,12 @@ const navLinks = sections
   .filter(s => s.id !== 'reviews' || hasReviews)
   .map(s => ({ href: `#${s.id}`, text: sectionLabels[s.id] }));
 
-const ctaText = isRestaurant ? 'Order Now' : 'Get Quote';
-const ctaHref = isRestaurant ? '#contact' : '#contact';
+const ctaText = isRestaurant ? 'Order Now' : hasTeam ? 'Book Now' : 'Get Quote';
+const ctaHref = isRestaurant ? '#contact' : hasTeam ? '#team' : '#contact';
 const heroCta = isRestaurant
   ? { text: 'View Our Menu', href: '#menu' }
+  : hasTeam
+  ? { text: 'Book Now', href: '#team' }
   : { text: 'Get Your Free Quote', href: '#contact' };
 // Load SVG icons for action bar
 const actionIcons = import.meta.glob('/src/assets/svgs/icons/*.svg', { query: '?raw', import: 'default', eager: true });


### PR DESCRIPTION
## Summary

- **Behold Instagram feed**: PhotoGallery now loads a live Behold.so widget when `beholdFeedId` is set in `gallery.json`. Falls back to static photo grid after 5s timeout if widget fails. CMS-editable via Pages CMS.
- **Products section**: New `products` content collection for businesses with items that have specs, tiered pricing, and tags (dumpster fleets, tinting packages, equipment rentals). Two-column card grid with featured badge, pricing table, and tag pills.
- **Team support**: Team component registered in sectionMap with salon/barber CTA routing (`Book Now` instead of `Get Quote`).
- **Gallery scroll variant**: Horizontal scroll layout option alongside existing masonry grid.

## Files changed

- `.pages.yml` — `beholdFeedId` field on gallery + full products collection CMS definition
- `src/components/PhotoGallery.astro` — Behold widget, scroll variant, fallback logic
- `src/components/Products.astro` — New product cards component
- `src/lib/types.ts` — Gallery.beholdFeedId, Product, ProductPricing, TeamMember, Team
- `src/pages/index.astro` — products + team in sectionMap/sectionLabels, team CTA routing

## Test plan

- [ ] Build passes clean (`npm run build`)
- [ ] No products dir = section doesn't render (existing sites unaffected)
- [ ] No beholdFeedId = static gallery unchanged (regression check)
- [ ] With beholdFeedId = Behold widget loads
- [ ] Products CMS collection appears in Pages CMS
- [ ] Gallery beholdFeedId field appears in Pages CMS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live Instagram feed integration to gallery with automatic fallback to static photos
  * Introduced product management system with product cards, pricing tiers, and tagging
  * Added team member management capabilities
  * Enhanced call-to-action buttons that dynamically adapt based on business type (Book Now for service businesses, Get Quote for others)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->