### PR TITLE
fix: use import.meta.glob for optional data files

### DIFF
--- a/src/components/BookShowcase.astro
+++ b/src/components/BookShowcase.astro
@@ -4,8 +4,8 @@
 // Reads from src/data/book.json. Designed for author/publisher sites.
 import OptimizedImg from './OptimizedImg.astro';
 
-let book: any = {};
-try { book = (await import('../data/book.json')).default; } catch {}
+const bookFiles = import.meta.glob<{ default: any }>('../data/book.json', { eager: true });
+const book: any = Object.values(bookFiles)[0]?.default || {};
 
 const title = book?.title || '';
 const subtitle = book?.subtitle || '';

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -10,8 +10,8 @@ import { formatPhone } from '../lib/utils';
 import OptimizedImg from './OptimizedImg.astro';
 import BrandName from './BrandName.astro';
 
-let googleLinks: any = {};
-try { googleLinks = (await import('../data/google-links.json')).default; } catch {}
+const glFiles = import.meta.glob<{ default: any }>('../data/google-links.json', { eager: true });
+const googleLinks: any = Object.values(glFiles)[0]?.default || {};
 
 const logoUrl = (client as any).logoUrl || '';
 const phoneForTel = (contact as any).phoneForTel || '';

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -18,8 +18,8 @@ const heroSubtitle = (hero as any)?.heroSubtitle || '';
 const marqueeItems = (theme as any)?.marqueeItems || [];
 
 // Hero stats from schema.json (authoritative source for rating/reviews)
-let schema: any = {};
-try { schema = (await import('../data/schema.json')).default; } catch {}
+const schemaFiles = import.meta.glob<{ default: any }>('../data/schema.json', { eager: true });
+const schema: any = Object.values(schemaFiles)[0]?.default || {};
 const aggregateRating = schema?.aggregateRating;
 const ratingValue = aggregateRating?.ratingValue ? String(aggregateRating.ratingValue) : '';
 const reviewCount = aggregateRating?.reviewCount ? String(aggregateRating.reviewCount) : '';

--- a/src/components/Reviews.astro
+++ b/src/components/Reviews.astro
@@ -25,8 +25,8 @@ const averageRating = (testimonials as any)?.averageRating || null;
 
 // Build the "See all reviews" link
 let allReviewsUrl = (client as any).socials?.google || '';
-let googleLinks: any = {};
-try { googleLinks = (await import('../data/google-links.json')).default; } catch {}
+const glFiles = import.meta.glob<{ default: any }>('../data/google-links.json', { eager: true });
+const googleLinks: any = Object.values(glFiles)[0]?.default || {};
 if (googleLinks?.allReviews) allReviewsUrl = googleLinks.allReviews;
 
 // Load source icons

--- a/src/components/ScrollMoment.astro
+++ b/src/components/ScrollMoment.astro
@@ -8,8 +8,8 @@ import hero from '../data/hero.json';
 import theme from '../data/theme.json';
 import OptimizedImg from './OptimizedImg.astro';
 
-let schema: any = {};
-try { schema = (await import('../data/schema.json')).default; } catch {}
+const schemaFiles = import.meta.glob<{ default: any }>('../data/schema.json', { eager: true });
+const schema: any = Object.values(schemaFiles)[0]?.default || {};
 
 const depth = (theme as any).layout?.depth || '';
 const items = testimonials?.items || [];

--- a/src/components/Team.astro
+++ b/src/components/Team.astro
@@ -12,7 +12,8 @@ interface Props { variant?: string | number; }
 const { variant: variantProp } = Astro.props;
 const variant = String(variantProp || 'cards');
 
-const teamData = await import('../data/team.json').then(m => m.default || m).catch(() => ({ items: [] }));
+const teamFiles = import.meta.glob<{ default: any }>('../data/team.json', { eager: true });
+const teamData = Object.values(teamFiles)[0]?.default || { items: [] };
 const members = resolveTeamMembers(teamData.items as TeamMemberRaw[]);
 
 const industry = (client.industry || '').toLowerCase();

--- a/src/components/TrustBar.astro
+++ b/src/components/TrustBar.astro
@@ -2,8 +2,8 @@
 // src/components/TrustBar.astro
 // PW Tint trust bar pattern: horizontal flex, large number/value + label,
 // vertical dividers, data-driven from trustbar.json, .reveal-up with stagger.
-let trustbar: any = { items: [] };
-try { trustbar = (await import('../data/trustbar.json')).default; } catch {}
+const tbFiles = import.meta.glob<{ default: any }>('../data/trustbar.json', { eager: true });
+const trustbar: any = Object.values(tbFiles)[0]?.default || { items: [] };
 
 const items = trustbar?.items || [];
 const hasItems = items.length > 0;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -33,18 +33,12 @@ import '../styles/menu.css';
 import { ClientRouter } from "astro:transitions";
 import TourOverlay from '../components/TourOverlay.astro';
 import type { TourData } from '../lib/types';
-import { existsSync, readFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 // tour.json is optional: preview sites have it, production sites don't.
-let tourData: TourData | undefined;
-{
-  const tourPath = resolve(dirname(fileURLToPath(import.meta.url)), '../data/tour.json');
-  if (existsSync(tourPath)) {
-    tourData = JSON.parse(readFileSync(tourPath, 'utf-8')) as TourData;
-  }
-}
+// Uses import.meta.glob (Vite-native) instead of node:fs — existsSync + import.meta.url
+// resolves to a virtual path during Astro build, causing tour markup to silently disappear.
+const tourFiles = import.meta.glob<{ default: TourData }>('../data/tour.json', { eager: true });
+const tourData: TourData | undefined = Object.values(tourFiles)[0]?.default;
 
 const typedBrand = brand as unknown as Brand;
 const typedTheme = theme as unknown as Theme;


### PR DESCRIPTION
## Summary
- **BaseLayout**: replaced `existsSync` + `import.meta.url` with `import.meta.glob` for tour.json loading. Vite transforms `import.meta.url` to a virtual path during Astro builds, so the file lookup silently failed — tour script was included but HTML markup was stripped out.
- **6 components** (BookShowcase, Hero, Footer, ScrollMoment, Reviews, TrustBar, Team): replaced `try/catch await import()` with `import.meta.glob`. Rollup statically analyzes dynamic imports and fails on missing files even inside try/catch, breaking builds for sites without book.json.
- All optional data imports now use `import.meta.glob` (Vite-native) which returns an empty object for missing files instead of throwing or resolving wrong paths.

## Files changed
- `src/layouts/BaseLayout.astro` — tour.json loading
- `src/components/BookShowcase.astro` — book.json
- `src/components/Hero.astro` — schema.json
- `src/components/Footer.astro` — google-links.json
- `src/components/ScrollMoment.astro` — schema.json
- `src/components/Reviews.astro` — google-links.json
- `src/components/TrustBar.astro` — trustbar.json
- `src/components/Team.astro` — team.json

## Test plan
- [x] Rebuilt all 5 client sites (cutsbyota, dcdrentals, martinezwelding, pwtint, sue-turflinger-ota) — all build successfully
- [x] Verified `id="tour-overlay"` HTML markup present in all 5 built index.html files
- [x] martinezwelding + pwtint (no book.json) now build without errors
- [ ] Visual verification of tour overlay on a served site with `?tour` param

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal data loading mechanisms across multiple components for improved performance and reliability at build time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->