### PR TITLE
fix: tour overlay z-index traps children behind page content

### DIFF
--- a/src/components/TourOverlay.astro
+++ b/src/components/TourOverlay.astro
@@ -144,8 +144,6 @@ const { tour } = Astro.props;
 
 <style>
   #tour-overlay {
-    position: fixed;
-    z-index: 0;
     pointer-events: none;
   }
 


### PR DESCRIPTION
## Summary
- `#tour-overlay` had `position: fixed; z-index: 0` which created a stacking context trapping all children at z-index 0
- The tour intro (z-index 9999) and floating button (z-index 899) rendered behind the sticky header and action bar
- Removed `position: fixed` and `z-index: 0` from the wrapper. Children are already `position: fixed` themselves.

## Test plan
- [ ] Visit any client site — floating "Tour this site" button should be visible bottom-right
- [ ] Visit with `?tour` — cinematic intro should overlay the entire page
- [ ] Button and intro should render above the sticky header and action bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted tour overlay positioning behavior to improve layout and stacking context handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->