### PR TITLE
fix: remove broken Google Maps embed

### DIFF
--- a/src/components/AboutMap.astro
+++ b/src/components/AboutMap.astro
@@ -13,7 +13,6 @@ const typedBrand = brand as unknown as Brand;
 const logoUrl = client.logoUrl || '';
 const aboutImage = (about as any).image || '';
 const address = [location.address, location.city, location.state, location.zip].filter(Boolean).join(', ');
-const mapQuery = encodeURIComponent(address);
 ---
 <section class="about-section section" id="about">
   <div class="container about-grid">
@@ -47,20 +46,6 @@ const mapQuery = encodeURIComponent(address);
         </div>
       )}
       <div class="about-map">
-        {address && (
-          <iframe
-            class="about-map-embed"
-            src={`https://www.google.com/maps?q=${mapQuery}&output=embed`}
-            width="100%"
-            height="200"
-            style="border:0; border-radius: var(--radius, 12px);"
-            allowfullscreen=""
-            loading="lazy"
-            sandbox="allow-scripts allow-same-origin"
-            referrerpolicy="no-referrer-when-downgrade"
-            title={`Map of ${client.name}`}
-          />
-        )}
         <p class="about-address">{location.address || ''}<br />{location.city || ''}, {location.state || ''} {location.zip || ''}</p>
         {location.mapLink && (
           <a href={location.mapLink} class="about-directions-link" target="_blank" rel="noopener">Get Directions →</a>
@@ -126,11 +111,6 @@ const mapQuery = encodeURIComponent(address);
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
-  }
-
-  .about-map-embed {
-    width: 100%;
-    border-radius: var(--radius, 12px);
   }
 
   .about-address {


### PR DESCRIPTION
## Problem

Google Maps iframe embed at `https://www.google.com/maps?q=ADDRESS&output=embed` is deprecated. Returns 403 or broken "can't load" page on every client site.

## Fix

Removed the iframe. Kept the address text and "Get Directions" link, which work without an API key.

## Test plan

- [ ] Build any fixture and verify about section renders address + directions link without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed embedded Google Maps display from the about page. Address information and "Get Directions" link remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->