### PR TITLE
fix(schema): declare contact form fields used by FloatingCTA and QuoteForm

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -170,6 +170,10 @@ export const contactSchema = z.object({
   email: z.string(),
   phoneForTel: z.string(),
   phone: z.string().optional(),
+  bookingUrl: z.string().optional(),
+  formTitle: z.string().optional(),
+  formDescription: z.string().optional(),
+  messagePlaceholder: z.string().optional(),
 }).loose();
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

\`Build and Deploy\` has been failing on every push since 2026-04-06 (12+ red runs in a row). The deploy job fails the \`Type check\` step (\`astro check\`) with two \`ts(2322)\` errors:

\`\`\`
src/components/FloatingCTA.astro:19  href={href}                       ts(2322)
src/components/QuoteForm.astro:138   placeholder={messagePlaceholder}  ts(2322)
\`\`\`

## Root cause

\`contactSchema\` in [src/lib/schemas.ts](src/lib/schemas.ts#L169) only declares \`email\`, \`phoneForTel\`, \`phone\` and uses \`.loose()\`:

\`\`\`ts
export const contactSchema = z.object({
  email: z.string(),
  phoneForTel: z.string(),
  phone: z.string().optional(),
}).loose();
\`\`\`

Under Zod's loose mode, any property not declared on the object is inferred as \`{}\` (the empty-object catchall) on the resulting type — not \`unknown\` or \`string | undefined\`. So when the new code does:

\`\`\`ts
const bookingUrl       = contact?.bookingUrl || '';                            // FloatingCTA.astro:7
const messagePlaceholder = contact.messagePlaceholder || \"How can we help?\";    // QuoteForm.astro:35
\`\`\`

\`contact.bookingUrl\` is typed \`{}\`, the \`||\` short-circuit yields \`{} | string\`, and assigning that to \`<a href={href}>\` (\`string | URL | null | undefined\`) or \`<textarea placeholder={…}>\` (\`string\`) is rejected by \`astro check\`.

This snuck in because the components were updated to read new fields without anyone updating the schema — the runtime works (the JSON contains them), but the type checker doesn't know about them.

## Fix

Declare the four fields the components actually read so they're inferred as \`string | undefined\`:

- \`bookingUrl\`        — used by \`FloatingCTA.astro\`
- \`formTitle\`         — used by \`QuoteForm.astro\`
- \`formDescription\`   — used by \`QuoteForm.astro\`
- \`messagePlaceholder\` — used by \`QuoteForm.astro\`

\`bookingLabel\` is intentionally NOT added — it's only used on \`team[].bookingLabel\`, never on \`contact\`.

## Test plan

- [x] \`npx astro check\` → **0 errors** (was: 2 errors)
- [x] \`npm test\` → **150 passed** (no schema regressions)
- [ ] Build and Deploy job goes green on this PR
- [ ] Visual: FloatingCTA still renders with bookingUrl, QuoteForm still picks up custom copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contact form configuration expanded with new optional fields: booking URLs, custom form titles, descriptions, and customizable message placeholders for enhanced contact experience personalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->