### PR TITLE
feat: aggregate-only reviews banner (Google ToS compliance)

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -193,27 +193,25 @@ content:
         type: string
         description: "Descriptive text below the main heading."
 
-  # ── Testimonials ──────────────────────────────────────────────────────────
+  # ── Testimonials (aggregate only — Google Places ToS compliance) ──────────
   - name: testimonials
     label: Customer Reviews
     type: file
     path: src/data/testimonials.json
     format: json
     fields:
-      - name: items
-        label: Reviews
-        type: object
-        list:
-          collapsible:
-            summary: "{{author}} ({{rating}} stars)"
-        fields:
-          - { name: text, label: Review Text, type: text }
-          - { name: author, label: Author Name, type: string }
-          - { name: initials, label: Initials, type: string, description: "Two letters shown in avatar circle" }
-          - { name: role, label: Role, type: string, default: "Verified Customer" }
-          - { name: rating, label: Rating, type: number, default: 5 }
-          - { name: source, label: Source, type: string, default: "Google" }
-          - { name: url, label: Review URL, type: string, required: false }
+      - name: reviewCount
+        label: Google Review Count
+        type: number
+        description: "Total number of Google reviews. Updated from Google automatically."
+      - name: averageRating
+        label: Google Rating
+        type: number
+        description: "Average star rating from Google. Updated automatically."
+      - name: allReviewsUrl
+        label: Google Reviews Link
+        type: string
+        description: "Link to all Google reviews. Leave empty to hide the link."
 
   # ── About Section ─────────────────────────────────────────────────────────
   - name: about

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ All data lives in `src/data/`. Files are plain JSON imported at build time. Opti
 | `seo.json` | Yes | pageTitle, metaDescription, ogTitle, ogDescription, ogImage, canonicalUrl |
 | `schema.json` | Yes | Full JSON-LD structured data (injected as `<script type="application/ld+json">`) |
 | `hours.json` | Yes | days[]: day, open, close (null = closed) |
-| `testimonials.json` | Yes | items[]: text, author, initials, role, rating, source, url; reviewCount |
+| `testimonials.json` | Yes | reviewCount, averageRating, allReviewsUrl (aggregate only — no individual review text per Google ToS) |
 | `trustbar.json` | Yes | items[]: number, label |
 | `faq.json` | Yes | items[]: question, answer, source |
 | `about.json` | Yes | heading, text |
@@ -111,7 +111,7 @@ Resolution order: explicit `component` override > variant override > default com
 | `process` | ProcessSteps | -- | `process.json` (optional, falls back to hardcoded steps) |
 | `gallery` | PhotoGallery | masonry, scroll | `gallery.json` + optional Behold feed |
 | `menu` | MenuSection | -- | `menu.json` |
-| `reviews` | Reviews | scroll | `testimonials.json` (skipped if items empty) |
+| `reviews` | Reviews | -- | `testimonials.json` (skipped if reviewCount and averageRating are 0/null) |
 | `faq` | FAQ | -- | `faq.json` |
 | `contact` | QuoteForm | order-visit -> OrderVisit | `contact.json` |
 | `about` | AboutMap | author-bio -> AuthorBio | `about.json`, `location.json` |
@@ -393,7 +393,7 @@ cd tests/visual && npx playwright test
 
 **Optional data files**: `tour.json` and `preview.json` are loaded via `import.meta.glob('../data/<file>.json', { eager: true })`, not direct import. This prevents build failures when the file is absent. Never use `fs.existsSync` or `import.meta.url` for optional files -- the path resolves incorrectly during Astro build.
 
-**Empty data arrays**: Components like Reviews check `testimonials.items.length > 0` before rendering. Empty arrays cause the section to be skipped, not crash.
+**Empty data arrays**: Components check data presence before rendering (e.g., Reviews checks `reviewCount > 0 || averageRating > 0`). Missing or empty data causes the section to be skipped, not crash.
 
 **Font not loading**: Ensure the font family name in `brand.json` exactly matches a key in `src/lib/fonts.ts` `FONT_REGISTRY`. Unregistered fonts fall back to system fonts silently.
 

--- a/src/components/Reviews.astro
+++ b/src/components/Reviews.astro
@@ -1,431 +1,146 @@
 ---
 // src/components/Reviews.astro
-// v4 upgrade: glass cards, accent left border, expandable details, avatar
-// initial circle, source icon, infinite auto-scroll with hover-pause,
-// review count from testimonials.reviewCount (NEVER items.length).
+// Aggregate reviews banner — Google Places ToS compliance (PR #335).
+// Shows rating + count + Google attribution + link. No individual review text.
 import { testimonials, client, googleLinks } from '../lib/data';
+import { getIcon } from '../lib/icons';
 
 interface Props { variant?: string | number; }
 
-// Always use scroll variant
-const variant = 'scroll';
-
-// Sort by rating desc so best review shows first
-const items = [...(testimonials?.items || [])].sort(
-  (a, b) => (b.rating || 0) - (a.rating || 0)
-);
-
-// Data-driven section headings and star visibility
-const sectionEyebrow = testimonials?.sectionEyebrow || 'Featured Reviews';
-const sectionTitle = testimonials?.sectionTitle || 'What Our Customers Say';
-const showStars = testimonials?.showStars !== false; // default true
-
-// Real review count from Google, NOT items.length
 const reviewCount = testimonials?.reviewCount
   || testimonials?.totalReviewCount
   || testimonials?.totalReviews
   || null;
 const averageRating = testimonials?.averageRating || null;
 
-// Build platform "See our reviews" links
-let googleReviewsUrl = client.socials?.google || '';
-if (googleLinks?.allReviews) googleReviewsUrl = googleLinks.allReviews;
-const yelpUrl = client.socials?.yelp || '';
-
-// Per-platform review detection for CTA gating
-const hasGoogleReviews = items.some((t) => (t.source || '').toLowerCase() === 'google');
-const hasYelpReviews = items.some((t) => (t.source || '').toLowerCase() === 'yelp');
-
-// Card link helper: only platform-sourced reviews link to their platform
-function cardUrl(t: typeof items[number]): string | undefined {
-  if (t.url) return t.url;
-  const src = (t.source || '').toLowerCase();
-  if (src === 'google' && googleReviewsUrl) return googleReviewsUrl;
-  if (src === 'yelp' && yelpUrl) return yelpUrl;
-  return undefined;
-}
-
-// Precompute card URLs (build-time only, avoids repeated calls in template)
-const enrichedItems = items.map((t) => ({ ...t, _url: cardUrl(t) }));
-
-// Keep for backward compat with meta subtitle link
-const allReviewsUrl = googleReviewsUrl;
-
-import { getIcon } from '../lib/icons';
+// Resolve Google reviews URL: allReviewsUrl > googleLinks > client social
+let allReviewsUrl = (testimonials as any)?.allReviewsUrl || '';
+if (!allReviewsUrl && googleLinks?.allReviews) allReviewsUrl = googleLinks.allReviews;
+if (!allReviewsUrl && client.socials?.google) allReviewsUrl = client.socials.google;
 
 // Star rendering helper
 function stars(count: number): string {
   return Array.from({ length: count }, () => '\u2605').join('');
 }
+
+const hasData = (reviewCount && reviewCount > 0) || (averageRating && averageRating > 0);
 ---
-{items.length > 0 && (
+{hasData && (
   <section class="reviews-section section" id="reviews" data-tour="reviews">
     <div class="container">
-      <div class="section-heading reveal-up">
-        <span class="section-eyebrow">{sectionEyebrow}</span>
-        <h2 class="section-title">{sectionTitle}</h2>
-        {(reviewCount || averageRating) && (
-          <p class="section-subtitle reviews-meta">
-            {averageRating && <span class="reviews-rating">{averageRating} <span class="reviews-meta-stars">{stars(Math.round(Number(averageRating)))}</span></span>}
-            {reviewCount && (
-              <span class="reviews-count">
-                {allReviewsUrl
-                  ? <a href={allReviewsUrl} target="_blank" rel="noopener">{reviewCount}+ Google Reviews</a>
-                  : <span>{reviewCount}+ Google Reviews</span>
-                }
-              </span>
-            )}
+      <div class="reviews-banner reveal-up">
+        {averageRating && (
+          <div class="reviews-rating-block">
+            <span class="reviews-rating-number">{averageRating}</span>
+            <span class="reviews-stars">{stars(Math.round(Number(averageRating)))}</span>
+          </div>
+        )}
+
+        {reviewCount && (
+          <p class="reviews-count-text">
+            {allReviewsUrl
+              ? <a href={allReviewsUrl} target="_blank" rel="noopener">{reviewCount}+ Reviews on Google</a>
+              : <span>{reviewCount}+ Reviews on Google</span>
+            }
           </p>
         )}
-      </div>
 
-      <div class="reviews-track" style={`--review-count: ${items.length}`}>
-        <div class="reviews-scroll">
-          {/* Original set */}
-          {enrichedItems.map((t) => t._url ? (
-            <a class="review-card review-card--linked" href={t._url} target="_blank" rel="noopener">
-              <div class="review-accent-border" />
-              {showStars && <div class="review-stars">{stars(t.rating ?? 0)}</div>}
-              <details class="review-text-wrap">
-                <summary class="review-text">{t.text}</summary>
-                <p class="review-text-full">{t.text}</p>
-              </details>
-              <div class="review-footer">
-                <span class="review-avatar">{t.initials}</span>
-                <div class="review-author-info">
-                  <span class="review-author">{t.author}</span>
-                  {t.role && <span class="review-role">{t.role}</span>}
-                </div>
-                <span class="review-badge">
-                  <span class="review-badge-icon" aria-hidden="true" set:html={getIcon(t.source?.toLowerCase() || 'star')} />
-                </span>
-              </div>
-            </a>
-          ) : (
-            <div class="review-card">
-              <div class="review-accent-border" />
-              {showStars && <div class="review-stars">{stars(t.rating ?? 0)}</div>}
-              <details class="review-text-wrap">
-                <summary class="review-text">{t.text}</summary>
-                <p class="review-text-full">{t.text}</p>
-              </details>
-              <div class="review-footer">
-                <span class="review-avatar">{t.initials}</span>
-                <div class="review-author-info">
-                  <span class="review-author">{t.author}</span>
-                  {t.role && <span class="review-role">{t.role}</span>}
-                </div>
-                <span class="review-badge">
-                  <span class="review-badge-icon" aria-hidden="true" set:html={getIcon(t.source?.toLowerCase() || 'star')} />
-                </span>
-              </div>
-            </div>
-          ))}
-          {/* Duplicate set for infinite scroll illusion */}
-          {enrichedItems.map((t) => t._url ? (
-            <a class="review-card review-card--linked" href={t._url} target="_blank" rel="noopener" aria-hidden="true" tabindex="-1">
-              <div class="review-accent-border" />
-              {showStars && <div class="review-stars">{stars(t.rating ?? 0)}</div>}
-              <details class="review-text-wrap">
-                <summary class="review-text">{t.text}</summary>
-                <p class="review-text-full">{t.text}</p>
-              </details>
-              <div class="review-footer">
-                <span class="review-avatar">{t.initials}</span>
-                <div class="review-author-info">
-                  <span class="review-author">{t.author}</span>
-                  {t.role && <span class="review-role">{t.role}</span>}
-                </div>
-                <span class="review-badge">
-                  <span class="review-badge-icon" aria-hidden="true" set:html={getIcon(t.source?.toLowerCase() || 'star')} />
-                </span>
-              </div>
-            </a>
-          ) : (
-            <div class="review-card" aria-hidden="true">
-              <div class="review-accent-border" />
-              {showStars && <div class="review-stars">{stars(t.rating ?? 0)}</div>}
-              <details class="review-text-wrap">
-                <summary class="review-text">{t.text}</summary>
-                <p class="review-text-full">{t.text}</p>
-              </details>
-              <div class="review-footer">
-                <span class="review-avatar">{t.initials}</span>
-                <div class="review-author-info">
-                  <span class="review-author">{t.author}</span>
-                  {t.role && <span class="review-role">{t.role}</span>}
-                </div>
-                <span class="review-badge">
-                  <span class="review-badge-icon" aria-hidden="true" set:html={getIcon(t.source?.toLowerCase() || 'star')} />
-                </span>
-              </div>
-            </div>
-          ))}
+        <div class="reviews-attribution">
+          <span class="reviews-google-icon" aria-hidden="true" set:html={getIcon('google')} />
+          <span class="reviews-attribution-text">Reviews from Google</span>
         </div>
-      </div>
 
-      {(hasGoogleReviews || hasYelpReviews) && (
-        <div class="reviews-ctas reveal-up">
-          {hasGoogleReviews && googleReviewsUrl && (
-            <a href={googleReviewsUrl} class="reviews-cta-btn" target="_blank" rel="noopener">
-              <span class="reviews-cta-icon" aria-hidden="true" set:html={getIcon('google')} />
-              {reviewCount ? `See our ${reviewCount}+ reviews on Google` : 'See our reviews on Google'}
-            </a>
-          )}
-          {hasYelpReviews && yelpUrl && (
-            <a href={yelpUrl} class="reviews-cta-btn" target="_blank" rel="noopener">
-              <span class="reviews-cta-icon" aria-hidden="true" set:html={getIcon('yelp')} />
-              See our reviews on Yelp
-            </a>
-          )}
-        </div>
-      )}
+        {allReviewsUrl && (
+          <a href={allReviewsUrl} class="reviews-cta" target="_blank" rel="noopener">
+            See all reviews &rarr;
+          </a>
+        )}
+      </div>
     </div>
   </section>
 )}
 
 <style>
-  /* ── Reviews Section ───────────────────────────────────────────── */
-
   .reviews-section {
     background: var(--background);
-    overflow: hidden;
   }
 
-  /* ── Review count metadata ─────────────────────────────────────── */
-
-  .reviews-meta {
+  .reviews-banner {
     display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-content: center;
-    gap: var(--gap, 1rem);
-    flex-wrap: wrap;
-  }
-
-  .reviews-rating {
-    font-family: var(--font-heading);
-    font-weight: 700;
-    font-size: var(--lead-size, 1.125rem);
-    color: var(--text);
-  }
-
-  .reviews-meta-stars {
-    color: var(--star-color);
-    letter-spacing: 1px;
-  }
-
-  .reviews-count {
-    font-size: var(--small-size, 0.875rem);
-    color: var(--textMuted, var(--text));
-  }
-
-  .reviews-count a {
-    color: var(--accent);
-    text-decoration: none;
-    font-weight: 600;
-  }
-
-  .reviews-count a:hover {
-    text-decoration: underline;
-  }
-
-  /* ── Scroll track ──────────────────────────────────────────────── */
-
-  .reviews-track {
-    margin-top: var(--gap-lg, 2rem);
-  }
-
-  .reviews-scroll {
-    display: flex;
-    gap: var(--gap-md, 1.5rem);
-    width: max-content;
-    animation: scroll-reviews calc(var(--review-count, 5) * 6s) linear infinite;
-  }
-
-  .reviews-scroll:hover {
-    animation-play-state: paused;
-  }
-
-  @keyframes scroll-reviews {
-    0% { transform: translateX(0); }
-    100% { transform: translateX(-50%); }
-  }
-
-  /* ── Review card: glass + accent border ─────────────────────────── */
-
-  .review-card {
-    position: relative;
+    gap: 0.75rem;
+    text-align: center;
+    padding: var(--gap-xl, 3rem) var(--gap-md, 1.5rem);
     background: color-mix(in oklch, var(--surface) 100%, white 6%);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
     border: 1px solid color-mix(in srgb, var(--accent) 15%, var(--border));
     border-radius: var(--card-radius, var(--radius, 12px));
-    padding: var(--gap-md, 1.5rem);
-    padding-left: calc(var(--gap-md, 1.5rem) + 3px);
-    width: 320px;
-    flex-shrink: 0;
-    text-decoration: none;
-    color: var(--text);
-    display: block;
-    overflow: hidden;
     box-shadow: var(--shadow-glass);
-    transition: transform var(--duration-normal, 0.4s) var(--ease-out-expo),
-                box-shadow var(--duration-normal, 0.4s) var(--ease-out-expo),
-                border-color var(--duration-normal, 0.4s) ease;
   }
 
-  .review-card:hover {
-    transform: translateY(-4px);
-    box-shadow: var(--shadow-card-hover);
-    border-color: color-mix(in srgb, var(--accent) 30%, var(--borderSubtle, var(--border)));
-    text-decoration: none;
+  .reviews-rating-block {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
   }
 
-  .review-card:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
+  .reviews-rating-number {
+    font-family: var(--font-heading);
+    font-weight: 800;
+    font-size: clamp(2rem, 4vw, 3rem);
+    color: var(--text);
+    line-height: 1;
   }
 
-  @media (min-width: 768px) {
-    .review-card {
-      width: 380px;
-    }
-  }
-
-  /* ── Accent left border ──────────────────────────────────────────── */
-
-  .review-accent-border {
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    width: 3px;
-    background: var(--accent);
-    border-radius: 0 2px 2px 0;
-  }
-
-  /* ── Stars ──────────────────────────────────────────────────────── */
-
-  .review-stars {
+  .reviews-stars {
     color: var(--star-color);
-    font-size: 1.125rem;
-    margin-bottom: var(--gap-sm, 0.5rem);
+    font-size: clamp(1.25rem, 2.5vw, 1.75rem);
     letter-spacing: 2px;
   }
 
-  /* ── Review text with expandable details ─────────────────────────── */
-
-  .review-text-wrap {
-    margin-bottom: 0.75rem;
-  }
-
-  .review-text-wrap summary {
-    cursor: pointer;
-    list-style: none;
-    display: -webkit-box;
-    -webkit-line-clamp: 4;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    line-height: var(--line-height-body, 1.6);
-    font-size: var(--small-size, 0.875rem);
+  .reviews-count-text {
+    font-size: var(--lead-size, 1.125rem);
     color: var(--textMuted, var(--text));
+    margin: 0;
   }
 
-  .review-text-wrap summary::-webkit-details-marker {
-    display: none;
-  }
-
-  .review-text-wrap[open] summary {
-    display: none;
-  }
-
-  .review-text-full {
-    line-height: var(--line-height-body, 1.6);
-    font-size: var(--small-size, 0.875rem);
-    color: var(--textMuted, var(--text));
-  }
-
-  /* ── Review footer: avatar + author + source ─────────────────────── */
-
-  .review-footer {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
-
-  .review-avatar {
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    background: color-mix(in srgb, var(--accent) 15%, var(--surface));
+  .reviews-count-text a {
     color: var(--accent);
+    text-decoration: none;
+    font-weight: 600;
+  }
+
+  .reviews-count-text a:hover {
+    text-decoration: underline;
+  }
+
+  .reviews-attribution {
     display: flex;
     align-items: center;
-    justify-content: center;
-    font-weight: 700;
-    font-size: var(--small-size, 0.875rem);
-    font-family: var(--font-heading);
-    flex-shrink: 0;
-    border: 1px solid color-mix(in srgb, var(--accent) 25%, transparent);
+    gap: 0.375rem;
+    opacity: 0.6;
   }
 
-  .review-author-info {
+  .reviews-google-icon {
     display: flex;
-    flex-direction: column;
-    gap: 0.125rem;
-    min-width: 0;
+    align-items: center;
   }
 
-  .review-author {
-    font-weight: 600;
-    font-size: var(--small-size, 0.875rem);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  .reviews-google-icon :global(svg) {
+    width: 16px;
+    height: 16px;
   }
 
-  .review-role {
+  .reviews-attribution-text {
     font-size: var(--caption-size, 0.75rem);
     color: var(--textMuted, var(--text));
   }
 
-  .review-badge {
-    margin-left: auto;
-    display: flex;
-    align-items: center;
-    flex-shrink: 0;
-  }
-
-  .review-badge-icon {
-    display: flex;
-    align-items: center;
-    color: var(--textMuted, var(--text));
-    opacity: 0.6;
-  }
-
-  .review-badge-icon :global(svg) {
-    width: 20px;
-    height: 20px;
-  }
-
-  .review-card--linked {
-    cursor: pointer;
-  }
-
-  /* ── See our reviews CTA buttons ──────────────────────────────── */
-
-  .reviews-ctas {
-    display: flex;
-    justify-content: center;
-    gap: var(--gap-md, 1.5rem);
-    flex-wrap: wrap;
-    margin-top: var(--gap-lg, 2rem);
-  }
-
-  .reviews-cta-btn {
+  .reviews-cta {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.375rem;
+    margin-top: 0.5rem;
     padding: 0.625rem 1.25rem;
     font-weight: 600;
     font-size: var(--small-size, 0.875rem);
@@ -437,36 +152,15 @@ function stars(count: number): string {
                 border-color var(--duration-fast, 0.2s) ease;
   }
 
-  .reviews-cta-btn:hover {
+  .reviews-cta:hover {
     background: color-mix(in srgb, var(--accent) 8%, transparent);
     border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
     text-decoration: none;
   }
 
-  .reviews-cta-icon {
-    display: flex;
-    align-items: center;
-    opacity: 0.7;
-  }
-
-  .reviews-cta-icon :global(svg) {
-    width: 18px;
-    height: 18px;
-  }
-
-  /* ── Focus-visible states ───────────────────────────────────────── */
-
-  .reviews-count a:focus-visible,
-  .reviews-cta-btn:focus-visible {
+  .reviews-cta:focus-visible,
+  .reviews-count-text a:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
-  }
-
-  /* ── Reduced motion ──────────────────────────────────────────────── */
-
-  @media (prefers-reduced-motion: reduce) {
-    .reviews-scroll {
-      animation: none;
-    }
   }
 </style>

--- a/src/components/Reviews.astro
+++ b/src/components/Reviews.astro
@@ -14,7 +14,7 @@ const reviewCount = testimonials?.reviewCount
 const averageRating = testimonials?.averageRating || null;
 
 // Resolve Google reviews URL: allReviewsUrl > googleLinks > client social
-let allReviewsUrl = (testimonials as any)?.allReviewsUrl || '';
+let allReviewsUrl = testimonials?.allReviewsUrl || '';
 if (!allReviewsUrl && googleLinks?.allReviews) allReviewsUrl = googleLinks.allReviews;
 if (!allReviewsUrl && client.socials?.google) allReviewsUrl = client.socials.google;
 
@@ -26,7 +26,7 @@ function stars(count: number): string {
 const hasData = (reviewCount && reviewCount > 0) || (averageRating && averageRating > 0);
 ---
 {hasData && (
-  <section class="reviews-section section" id="reviews" data-tour="reviews">
+  <section class="reviews-section section" id="reviews" data-tour="reviews" aria-label="Customer Reviews">
     <div class="container">
       <div class="reviews-banner reveal-up">
         {averageRating && (

--- a/src/components/TrustStats.astro
+++ b/src/components/TrustStats.astro
@@ -7,16 +7,13 @@ import { client, testimonials } from '../lib/data';
 const foundingYear = parseInt(String(client.foundingYear || '0'), 10);
 const hasFoundingYear = foundingYear > 1900;
 
-const reviews = testimonials?.items || [];
 const reviewCount = testimonials?.reviewCount
   || testimonials?.totalReviewCount
   || testimonials?.totalReviews
-  || reviews.length;
+  || 0;
 const avgRating = testimonials?.averageRating
   ? String(testimonials.averageRating)
-  : reviews.length > 0
-    ? (reviews.reduce((sum: number, r) => sum + (r.rating || 0), 0) / reviews.length).toFixed(1)
-    : '0';
+  : '0';
 const hasRating = parseFloat(avgRating) > 0;
 const hasReviews = reviewCount > 0;
 

--- a/src/data/testimonials.json
+++ b/src/data/testimonials.json
@@ -1,51 +1,5 @@
 {
-  "items": [
-    {
-      "text": "We decided to try Duran Station since we have not been since Covid. Food was incredible and reasonably priced. Red chile was hot! Great place and our server Sarah was awesome. We will be back to this family owned restaurant!",
-      "author": "Virginia Contreras",
-      "initials": "VC",
-      "role": "Verified Customer",
-      "rating": 5,
-      "source": "Google",
-      "url": "https://www.google.com/maps/contrib/104025508128328869941/reviews"
-    },
-    {
-      "text": "First time at Duran's Station  Restaurant..\nI did not know there were two locations.  I've only been to Duran's in the Pharmacy.. But this place is definitely great ! I haven't had Duran's  in about seven years.. made it back to albuquerque and thought better get my Red chile fix.  I am so glad I did.   Everything  was perfect !  Got there after the lunch rush. No waiting.. big booth to myself.. ordered  the carne adovada  stuffed sopaipilla. That was the ultimate  meal.. fresh pintos, fresh tender chunks of well seasoned  pork.. Over a crunchy  Sopaipilla.. Smothered with  red chile and garnish.. that was so delicious  ! It was perfect.. Shout out to Shyanne,  my great and wonderful waitress/server.. she is awesome.. very  knowledgeable  of the menu and what is recommended.. she was on point ! Thank You  Esmeralda for your kind and great customer  service.. you are a valuable asset to Duran's  restaurant.. you definitely go above and beyond to provide great service and atmosphere  for all to enjoy !  Ho pi e to see ya'll  soon.. 🙏",
-      "author": "Anthony Montes",
-      "initials": "AM",
-      "role": "Verified Customer",
-      "rating": 5,
-      "source": "Google",
-      "url": "https://www.google.com/maps/contrib/110446210442167337021/reviews"
-    },
-    {
-      "text": "Very nice authentic New Mexican food. Fritto pie for $11?!  It's good food and very nice staff and owner they assemble plates right in front of you very clean amd tasty. Portions are not a two pounds of rice and beans ! But priced reasonably, good quality amd atmosphere. I enjoyed going there and will go again. You see a picture with empty seat? Yeah good luck with that ! It's always packed and better catch it a bit off rush hours. Hope you enjoy it.",
-      "author": "Reza Moghadam",
-      "initials": "RM",
-      "role": "Verified Customer",
-      "rating": 5,
-      "source": "Google",
-      "url": "https://www.google.com/maps/contrib/105114022120940709699/reviews"
-    },
-    {
-      "text": "I like simple when it comes to nachos… and the nachos at Duran’s Station were perfect! The nachos come with melted shredded cheese, pinto beans, and jalapeños. I also tried their hamburger steak plate with fried potatoes. I’m not a fan of steam potatoes so I’m glad they have options. And their red chile is so tasty! Some of the best I’ve had in town. I know Duran’s Central Pharmacy is talked about more, but in my opinion, Duran’s Station better.",
-      "author": "Alexandria Gonzalez",
-      "initials": "AG",
-      "role": "Verified Customer",
-      "rating": 5,
-      "source": "Google",
-      "url": "https://www.google.com/maps/contrib/114914857477030519677/reviews"
-    },
-    {
-      "text": "Disclaimer: not from around here, so there may be some local perspectives I'm missing.  This is a no frills, but quality dining experience. I had the flat cheese enchiladas - a throw back to my childhood when these things were comfort food. Its very difficult to find flat (stacked) enchiladas in places I tend to travel. Duran's Station's enchiladas were good: simple, spicy, and tasty. Very tasty.  I followed my main with a single, fresh sopapilla & honey, which is just what I needed to take the spicy edge off.  Sarah was warm and welcoming, and hosted me with a smile.  It was a great experience for this brief stopover in Albuquerque.",
-      "author": "Ken Phillips",
-      "initials": "KP",
-      "role": "Verified Customer",
-      "rating": 4,
-      "source": "Google",
-      "url": "https://www.google.com/maps/contrib/113746058749493948094/reviews"
-    }
-  ],
   "reviewCount": 1069,
-  "averageRating": 4.5
+  "averageRating": 4.5,
+  "allReviewsUrl": ""
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -251,10 +251,11 @@ export const testimonialSchema = z.object({
 }).loose();
 
 export const testimonialsSchema = z.object({
-  items: z.array(testimonialSchema),
-  reviewCount: z.number().optional(),
-  averageRating: z.number().optional(),
-  // Accessed by TrustStats and Reviews as fallback names
+  items: z.array(testimonialSchema).optional(),
+  reviewCount: z.number().nullable().optional(),
+  averageRating: z.number().nullable().optional(),
+  allReviewsUrl: z.string().optional().default(''),
+  // Legacy field names (backward compat)
   totalReviewCount: z.number().optional(),
   totalReviews: z.number().optional(),
 }).loose();

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,7 +37,7 @@ import { DEFAULT_COMPONENTS, VARIANT_OVERRIDES, resolveNavLabels, resolveCta, re
 import { contact, location, testimonials, theme } from '../lib/data';
 import type { SectionEntry } from '../lib/types';
 
-const hasReviews = (testimonials?.items?.length ?? 0) > 0;
+const hasReviews = (testimonials?.reviewCount ?? 0) > 0 || (testimonials?.averageRating ?? 0) > 0;
 
 // Component lookup by name string
 const componentMap: Record<string, any> = {


### PR DESCRIPTION
## Summary
- Replaced individual review card carousel with aggregate reviews banner (rating + count + Google attribution + "See all reviews" link)
- Updated `testimonialsSchema` to make `items` optional and add `allReviewsUrl` field
- Updated `hasReviews` gate in `index.astro` from `items.length > 0` to `reviewCount > 0 || averageRating > 0`
- Removed individual review text from sample `testimonials.json`

**Why:** Google Places API ToS Section 10.5(d) restricts caching individual review text beyond 30 days. Aggregate data (rating + count) is compliant with proper attribution. Companion to ziamade/ziamade-platform#335 which updated the pipeline to emit aggregate-only `testimonials.json`.

## Test plan
- [x] `npm run build` passes cleanly
- [ ] Visual verification: reviews section renders rating, stars, count, Google "G" icon, and "See all reviews" link
- [ ] Section hidden when `reviewCount` and `averageRating` are both null/0
- [ ] Dark mode renders correctly
- [ ] Existing sites with `items` array still build (schema backward compat via `.optional()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a single aggregate Reviews banner showing average rating, review count, attribution, and a "See all reviews" link.

* **Refactor**
  * Replaced scrollable individual review cards and related animations with the streamlined banner.
  * Reviews section now appears based on aggregate rating/count presence rather than per-item list.

* **Documentation**
  * Content schema updated to emphasize aggregate review fields and link behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->