### PR TITLE
fix: photo-first variant polish pass

### DIFF
--- a/src/components/Facility.astro
+++ b/src/components/Facility.astro
@@ -19,17 +19,20 @@ const heading = (facilitySection as any)?.heading || 'Our Shop';
   <section class="section facility-section" id="facility">
     <div class="container">
       <h2 class="section-heading reveal-up">{heading}</h2>
-      <div class="facility-grid stagger-parent">
-        {facilityImages.map((img: any) => (
-          <div class="facility-card reveal-up">
-            <OptimizedImg
-              src={img.url || img.image || ''}
-              alt={img.alt || 'Our facility'}
-              width={800}
-              height={600}
-            />
-          </div>
-        ))}
+      <div class="facility-scroll-wrap">
+        <div class="facility-grid stagger-parent">
+          {facilityImages.map((img: any) => (
+            <div class="facility-card reveal-up">
+              <OptimizedImg
+                src={img.url || img.image || ''}
+                alt={img.alt || 'Our facility'}
+                width={800}
+                height={600}
+              />
+            </div>
+          ))}
+        </div>
+        <div class="facility-fade" aria-hidden="true"></div>
       </div>
     </div>
   </section>
@@ -50,6 +53,26 @@ const heading = (facilitySection as any)?.heading || 'Our Shop';
     display: none;
   }
 
+  .facility-scroll-wrap {
+    position: relative;
+  }
+
+  .facility-fade {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0.5rem;
+    width: 60px;
+    background: linear-gradient(to left, var(--background, #000) 0%, transparent 100%);
+    pointer-events: none;
+    z-index: 1;
+    transition: opacity 0.3s ease;
+  }
+
+  .facility-scroll-wrap.scrolled-end .facility-fade {
+    opacity: 0;
+  }
+
   .facility-card {
     flex: 0 0 auto;
     width: min(360px, 75vw);
@@ -58,6 +81,7 @@ const heading = (facilitySection as any)?.heading || 'Our Shop';
     aspect-ratio: 4 / 3;
     box-shadow: var(--shadow-card);
     scroll-snap-align: start;
+    scroll-snap-stop: always;
   }
 
   .facility-card :global(img),
@@ -77,6 +101,9 @@ const heading = (facilitySection as any)?.heading || 'Our Shop';
     .facility-card {
       width: 85vw;
     }
+    .facility-fade {
+      width: 40px;
+    }
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -90,3 +117,21 @@ const heading = (facilitySection as any)?.heading || 'Our Shop';
     }
   }
 </style>
+
+<script>
+  function initFacilityScroll() {
+    const wraps = document.querySelectorAll('.facility-scroll-wrap');
+    wraps.forEach(wrap => {
+      const scroll = wrap.querySelector('.facility-grid');
+      if (!scroll) return;
+      function checkScroll() {
+        const atEnd = scroll!.scrollLeft + scroll!.clientWidth >= scroll!.scrollWidth - 10;
+        wrap.classList.toggle('scrolled-end', atEnd);
+      }
+      scroll.addEventListener('scroll', checkScroll, { passive: true });
+      checkScroll();
+    });
+  }
+
+  document.addEventListener('astro:page-load', initFacilityScroll);
+</script>

--- a/src/components/PhotoGallery.astro
+++ b/src/components/PhotoGallery.astro
@@ -117,7 +117,10 @@ const beholdFeedId = gallery?.beholdFeedId || '';
             const catImages = categorized.filter((img: any) => img.category === cat);
             return (
               <div class="gallery-row">
-                <h3 class="gallery-row__label">{cat.charAt(0).toUpperCase() + cat.slice(1)}</h3>
+                <h3 class="gallery-row__label">
+                  {cat.charAt(0).toUpperCase() + cat.slice(1)}
+                  <span class="gallery-row__count">{catImages.length} {catImages.length === 1 ? 'photo' : 'photos'}</span>
+                </h3>
                 <div class="gallery-row__scroll-wrap">
                 <div class="gallery-row__scroll">
                   {catImages.map((img: any) => {
@@ -157,7 +160,11 @@ const beholdFeedId = gallery?.beholdFeedId || '';
           })}
           {uncategorized.length > 0 && (
             <div class="gallery-row">
-              <h3 class="gallery-row__label">More</h3>
+              <h3 class="gallery-row__label">
+                More
+                <span class="gallery-row__count">{uncategorized.length} {uncategorized.length === 1 ? 'photo' : 'photos'}</span>
+              </h3>
+              <div class="gallery-row__scroll-wrap">
               <div class="gallery-row__scroll">
                 {uncategorized.map((img: any) => {
                   const idx = allVisible.indexOf(img);
@@ -188,6 +195,8 @@ const beholdFeedId = gallery?.beholdFeedId || '';
                     </button>
                   );
                 })}
+              </div>
+              <div class="gallery-row__fade" aria-hidden="true"></div>
               </div>
             </div>
           )}
@@ -534,12 +543,21 @@ const beholdFeedId = gallery?.beholdFeedId || '';
 
   .gallery-row__label {
     font-family: var(--font-heading);
-    font-size: 0.85rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--text);
+    margin: 0;
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    margin-bottom: var(--gap-sm, 0.75rem);
+  }
+
+  .gallery-row__count {
+    font-family: var(--font-body, sans-serif);
+    font-size: 0.75rem;
+    font-weight: 400;
     color: var(--textMuted);
-    margin: 0 0 var(--gap-sm, 0.5rem);
   }
 
   .gallery-row__scroll {

--- a/src/components/ProjectGallery.astro
+++ b/src/components/ProjectGallery.astro
@@ -491,6 +491,30 @@ const hasProjects = items.length > 0;
     prevBtn?.addEventListener('click', () => goTo(current - 1));
     nextBtn?.addEventListener('click', () => goTo(current + 1));
     dots.forEach((dot, i) => dot.addEventListener('click', () => goTo(i)));
+
+    // Touch swipe navigation
+    let touchStartX = 0;
+    let touchStartY = 0;
+
+    carousel.addEventListener('touchstart', (e: TouchEvent) => {
+      touchStartX = e.touches[0].clientX;
+      touchStartY = e.touches[0].clientY;
+    }, { passive: true });
+
+    carousel.addEventListener('touchend', (e: TouchEvent) => {
+      const deltaX = e.changedTouches[0].clientX - touchStartX;
+      const deltaY = e.changedTouches[0].clientY - touchStartY;
+      if (Math.abs(deltaX) > 50 && Math.abs(deltaX) > Math.abs(deltaY)) {
+        if (deltaX < 0) goTo(current + 1);
+        else goTo(current - 1);
+      }
+    }, { passive: true });
+
+    // Keyboard navigation (arrow keys when carousel focused)
+    carousel.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); goTo(current - 1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); goTo(current + 1); }
+    });
   }
 
   document.addEventListener('astro:page-load', initProjectCarousel);

--- a/src/components/ProjectGallery.astro
+++ b/src/components/ProjectGallery.astro
@@ -19,7 +19,7 @@ const hasProjects = items.length > 0;
       
       {/* -- Carousel variant ------------------------------------------- */}
       {variantStr === 'carousel' && (
-        <div class="projects-carousel" data-carousel>
+        <div class="projects-carousel" data-carousel tabindex="0" role="region" aria-roledescription="carousel" aria-label="Project showcase">
           <div class="projects-carousel__track">
             {items.map((project, i) => (
               <div class={`projects-carousel__slide ${i === 0 ? 'projects-carousel__slide--active' : ''}`} data-slide={i} aria-hidden={i !== 0 ? 'true' : undefined}>
@@ -315,11 +315,17 @@ const hasProjects = items.length > 0;
   }
 
   .projects-carousel__slide {
-    display: none;
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.4s ease;
   }
 
   .projects-carousel__slide--active {
-    display: block;
+    position: relative;
+    opacity: 1;
+    pointer-events: auto;
   }
 
   .projects-carousel__slide .project-slider-wrap {
@@ -448,6 +454,10 @@ const hasProjects = items.length > 0;
     }
 
     .project-slider-knob {
+      transition: none;
+    }
+
+    .projects-carousel__slide {
       transition: none;
     }
   }

--- a/src/components/ProjectGallery.astro
+++ b/src/components/ProjectGallery.astro
@@ -170,6 +170,7 @@ const hasProjects = items.length > 0;
     overflow: hidden;
     cursor: col-resize;
     background: var(--surface);
+    touch-action: none;
   }
 
   /* ── Images: stacked via absolute positioning ───────────────────── */
@@ -517,5 +518,72 @@ const hasProjects = items.length > 0;
     });
   }
 
+  function initSliders() {
+    document.querySelectorAll<HTMLElement>('.project-slider').forEach(slider => {
+      const wrap = slider.querySelector<HTMLElement>('.project-slider-wrap');
+      const handle = slider.querySelector<HTMLElement>('.project-slider-handle');
+      if (!wrap || !handle) return;
+
+      const beforeImg = wrap.querySelector<HTMLElement>('.project-img--before');
+      if (!beforeImg) return;
+
+      let dragging = false;
+
+      function updateSlider(clientX: number) {
+        const rect = wrap!.getBoundingClientRect();
+        let pct = ((clientX - rect.left) / rect.width) * 100;
+        pct = Math.max(0, Math.min(100, pct));
+        beforeImg!.style.clipPath = `inset(0 ${100 - pct}% 0 0)`;
+        handle!.style.left = `${pct}%`;
+        handle!.setAttribute('aria-valuenow', String(Math.round(pct)));
+      }
+
+      // Mouse drag
+      handle.addEventListener('mousedown', (e: MouseEvent) => {
+        e.preventDefault();
+        dragging = true;
+      });
+
+      document.addEventListener('mousemove', (e: MouseEvent) => {
+        if (!dragging) return;
+        updateSlider(e.clientX);
+      });
+
+      document.addEventListener('mouseup', () => {
+        dragging = false;
+      });
+
+      // Touch drag
+      handle.addEventListener('touchstart', (e: TouchEvent) => {
+        e.stopPropagation();
+        dragging = true;
+      }, { passive: true });
+
+      wrap.addEventListener('touchmove', (e: TouchEvent) => {
+        if (!dragging) return;
+        e.preventDefault();
+        e.stopPropagation();
+        updateSlider(e.touches[0].clientX);
+      }, { passive: false });
+
+      wrap.addEventListener('touchend', (e: TouchEvent) => {
+        if (dragging) e.stopPropagation();
+        dragging = false;
+      }, { passive: true });
+
+      // Keyboard: arrow keys move slider 5% per press
+      handle.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+        e.preventDefault();
+        e.stopPropagation();
+        const currentVal = parseInt(handle.getAttribute('aria-valuenow') || '50');
+        const next = e.key === 'ArrowLeft' ? Math.max(0, currentVal - 5) : Math.min(100, currentVal + 5);
+        const rect = wrap!.getBoundingClientRect();
+        updateSlider(rect.left + (next / 100) * rect.width);
+      });
+    });
+  }
+
   document.addEventListener('astro:page-load', initProjectCarousel);
+  document.addEventListener('astro:page-load', initSliders);
 </script>

--- a/src/components/ServiceCards.astro
+++ b/src/components/ServiceCards.astro
@@ -220,6 +220,7 @@ const splitRemaining = featured.length > 0
       flex: 0 0 85vw;
       max-width: 340px;
       scroll-snap-align: center;
+      scroll-snap-stop: always;
     }
   }
 

--- a/src/components/TourOverlay.astro
+++ b/src/components/TourOverlay.astro
@@ -230,7 +230,10 @@ const { tour } = Astro.props;
 
   .tour-trigger {
     position: fixed;
-    bottom: 5.5rem;
+    /* Float above the preview overlay bar when it's open.
+       --zm-overlay-bottom-height is set dynamically by overlay.ts.
+       Falls back to 5.5rem (normal position) when no overlay is active. */
+    bottom: max(5.5rem, calc(var(--zm-overlay-bottom-height, 0px) + 1.25rem));
     right: 1.25rem;
     z-index: 899;
     pointer-events: auto;
@@ -261,7 +264,7 @@ const { tour } = Astro.props;
 
   @media (max-width: 640px) {
     .tour-trigger__label { display: none; }
-    .tour-trigger { padding: 0.75rem; bottom: 5rem; }
+    .tour-trigger { padding: 0.75rem; bottom: max(5rem, calc(var(--zm-overlay-bottom-height, 0px) + 1.25rem)); }
   }
 
   @keyframes tourFadeIn {


### PR DESCRIPTION
## Summary
- **Category-grid gallery**: Bold labels (1.15rem, title case) with photo count, fix "More" row missing fade gradient wrapper
- **Project carousel**: Crossfade slide transitions, touch swipe navigation, keyboard arrow keys, ARIA carousel attributes
- **Before/after slider**: Touch drag support, keyboard arrow keys (5% per press), proper stopPropagation to avoid carousel conflicts
- **Facility section**: Right-edge fade gradient with scroll-end detection (matches gallery pattern), scroll-snap-stop
- **Service cards**: scroll-snap-stop on mobile carousel

## Test Plan
- [ ] Build succeeds (`npm run build`)
- [ ] Category-grid labels are larger, bold, title case with photo counts
- [ ] "More" row has right-edge fade gradient
- [ ] Carousel slides crossfade (not instant toggle)
- [ ] Touch swipe navigates carousel slides
- [ ] Arrow keys navigate carousel when focused
- [ ] Before/after slider responds to touch drag on mobile
- [ ] Before/after slider responds to arrow keys when handle focused
- [ ] Facility section has right-edge fade that hides at scroll end
- [ ] Service cards snap one-at-a-time on mobile
- [ ] `prefers-reduced-motion: reduce` disables carousel transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic photo counts to gallery category labels.
  * Enhanced carousel with keyboard navigation (arrow keys) and touch swipe support.
  * Improved before/after image slider with keyboard, mouse, and touch controls.
  * Added fade overlay effect to facility image scrolling.

* **Improvements**
  * Enhanced scroll snapping behavior for carousels and scrollable content.
  * Strengthened carousel accessibility with ARIA labels and focus management.
  * Refined tour trigger button positioning for better layout integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->