### PR TITLE
refactor(brand): reduce palette to 6 core colors

### DIFF
--- a/src/lib/__tests__/brand.test.ts
+++ b/src/lib/__tests__/brand.test.ts
@@ -92,6 +92,31 @@ describe('paletteToCSS', () => {
     expect(css).toContain('--accent:');
     expect(css).toContain('--text:');
   });
+
+  it('derives accentDim, accentGlow, border, borderSubtle from core 6', () => {
+    const core6 = {
+      bg: '#F5F0EB',
+      surface: '#E8E1D8',
+      surfaceAlt: '#EDE7DF',
+      text: '#1C2428',
+      textMuted: '#5A6268',
+      accent: '#8A5D04',
+    };
+    const css = paletteToCSS(core6 as any);
+    // accentDim derived as rgba of accent at 0.6
+    expect(css).toContain('--accentDim: rgba(138, 93, 4, 0.6)');
+    // accentGlow derived as rgba of accent at 0.2
+    expect(css).toContain('--accentGlow: rgba(138, 93, 4, 0.2)');
+    // border and borderSubtle should be present (derived from bg)
+    expect(css).toContain('--border:');
+    expect(css).toContain('--borderSubtle:');
+  });
+
+  it('uses explicit accentDim/accentGlow/border when provided', () => {
+    const css = paletteToCSS(darkPalette as any);
+    // darkPalette has explicit accentDim '#b8845e' — should use it, not derive
+    expect(css).toContain('--accentDim: #b8845e');
+  });
 });
 
 describe('getContrastRatio', () => {

--- a/src/lib/brand.ts
+++ b/src/lib/brand.ts
@@ -59,12 +59,54 @@ export function getContrastRatio(hex1: string, hex2: string): number {
   return (lighter + 0.05) / (darker + 0.05);
 }
 
+/** Derive accentDim (accent at 0.6 opacity) from a hex accent color. */
+function deriveAccentDim(accentHex: string): string {
+  const rgb = parseHex(accentHex);
+  if (!rgb) return 'rgba(128, 128, 128, 0.6)';
+  return `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, 0.6)`;
+}
+
+/** Derive accentGlow (accent at 0.2 opacity) from a hex accent color. */
+function deriveAccentGlow(accentHex: string): string {
+  const rgb = parseHex(accentHex);
+  if (!rgb) return 'rgba(128, 128, 128, 0.2)';
+  return `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, 0.2)`;
+}
+
+/** Derive border color from bg — darken for light palettes, lighten for dark. */
+function deriveBorder(bgHex: string): string {
+  const rgb = parseHex(bgHex);
+  if (!rgb) return '#E0E0E0';
+  const light = isLightColor(bgHex);
+  const factor = light ? 0.85 : 1.4;
+  const clamp = (v: number) => Math.min(255, Math.max(0, Math.round(v * factor)));
+  return `#${clamp(rgb[0]).toString(16).padStart(2, '0')}${clamp(rgb[1]).toString(16).padStart(2, '0')}${clamp(rgb[2]).toString(16).padStart(2, '0')}`;
+}
+
+/** Derive borderSubtle — midpoint between bg and border. */
+function deriveBorderSubtle(bgHex: string, borderHex: string): string {
+  const bgRgb = parseHex(bgHex);
+  const borderRgb = parseHex(borderHex);
+  if (!bgRgb || !borderRgb) return borderHex;
+  const mid = (a: number, b: number) => Math.round((a + b) / 2);
+  return `#${mid(bgRgb[0], borderRgb[0]).toString(16).padStart(2, '0')}${mid(bgRgb[1], borderRgb[1]).toString(16).padStart(2, '0')}${mid(bgRgb[2], borderRgb[2]).toString(16).padStart(2, '0')}`;
+}
+
 /**
  * Generate CSS custom properties from a single color palette.
  * v4: Single palette, no light/dark toggle.
+ * Accepts either the full 10-key palette or just the 6 core colors
+ * (bg, surface, surfaceAlt, text, textMuted, accent) — derived colors
+ * are auto-computed when omitted.
  */
 export function paletteToCSS(palette: ColorPalette): string {
   const vars: string[] = [];
+
+  // Derive optional colors from core 6
+  const accentDim = palette.accentDim ?? deriveAccentDim(palette.accent);
+  const accentGlow = palette.accentGlow ?? deriveAccentGlow(palette.accent);
+  const border = palette.border ?? deriveBorder(palette.bg);
+  const borderSubtle = palette.borderSubtle ?? deriveBorderSubtle(palette.bg, border);
 
   // Core palette
   vars.push(`  --bg: ${cssSafe(palette.bg)};`);
@@ -74,16 +116,10 @@ export function paletteToCSS(palette: ColorPalette): string {
   vars.push(`  --text: ${cssSafe(palette.text)};`);
   vars.push(`  --textMuted: ${cssSafe(palette.textMuted)};`);
   vars.push(`  --accent: ${cssSafe(palette.accent)};`);
-  vars.push(`  --accentDim: ${cssSafe(palette.accentDim)};`);
-  vars.push(`  --accentGlow: ${cssSafe(palette.accentGlow)};`);
-  vars.push(`  --border: ${cssSafe(palette.border)};`);
-
-  // Optional
-  if (palette.borderSubtle) {
-    vars.push(`  --borderSubtle: ${cssSafe(palette.borderSubtle)};`);
-  } else {
-    vars.push(`  --borderSubtle: ${cssSafe(palette.border)};`);
-  }
+  vars.push(`  --accentDim: ${cssSafe(accentDim)};`);
+  vars.push(`  --accentGlow: ${cssSafe(accentGlow)};`);
+  vars.push(`  --border: ${cssSafe(border)};`);
+  vars.push(`  --borderSubtle: ${cssSafe(borderSubtle)};`);
 
   // Derived glass surfaces — auto-detect light/dark palette
   const glassBase = isLightColor(palette.bg) ? '0, 0, 0' : '255, 255, 255';

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -62,15 +62,17 @@ export const clientSchema = z.object({
 // ---------------------------------------------------------------------------
 
 export const colorPaletteSchema = z.object({
+  // Core 6 — required, these define the palette
   bg: cssColor,
   surface: cssColor,
   surfaceAlt: cssColor,
   text: cssColor,
   textMuted: cssColor,
   accent: cssColor,
-  accentDim: cssColor,
-  accentGlow: cssColor,
-  border: cssColor,
+  // Derived 4 — optional, auto-computed from core 6 by paletteToCSS() when omitted
+  accentDim: cssColor.optional(),
+  accentGlow: cssColor.optional(),
+  border: cssColor.optional(),
   borderSubtle: cssColor.optional(),
 }).loose();
 


### PR DESCRIPTION
## Summary
- Makes `accentDim`, `accentGlow`, `border`, `borderSubtle` optional in the color palette schema
- `paletteToCSS()` now auto-derives these from the 6 core colors (`bg`, `surface`, `surfaceAlt`, `text`, `textMuted`, `accent`) when omitted
- Existing brand.json files with all 10 colors continue to work unchanged (backward compatible)

## Test plan
- [x] All 13 brand.ts unit tests pass (including 2 new derivation tests)
- [ ] Build an existing site with a 10-color brand.json — verify no visual regression
- [ ] Build a site with a 6-color brand.json — verify derived colors render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Color palette system now automatically derives optional accent and border color variations when not explicitly provided in a palette definition, reducing required configuration. Explicit palette values take precedence over automatic derivation when supplied.

* **Tests**
  * Expanded test coverage validating color palette auto-derivation logic and precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->