### PR TITLE
feat(hero): add HeroText variant (text-only) for weak-photo clients

### DIFF
--- a/src/__tests__/section-registry.test.ts
+++ b/src/__tests__/section-registry.test.ts
@@ -58,6 +58,18 @@ describe('resolveComponent', () => {
     expect(resolveComponent('trust')).toBe('TrustBar');
   });
 
+  it('hero variant "text" resolves to HeroText', () => {
+    expect(resolveComponent('hero', 'text')).toBe('HeroText');
+  });
+
+  it('hero default resolves to Hero (no variant given)', () => {
+    expect(resolveComponent('hero')).toBe('Hero');
+  });
+
+  it('hero unknown variant falls back to Hero', () => {
+    expect(resolveComponent('hero', 'nonexistent')).toBe('Hero');
+  });
+
   it('ignores unknown variant and returns default', () => {
     expect(resolveComponent('trust', 'nonexistent')).toBe('TrustBar');
     expect(resolveComponent('contact', 'nonexistent')).toBe('QuoteForm');

--- a/src/components/HeroText.astro
+++ b/src/components/HeroText.astro
@@ -1,0 +1,416 @@
+---
+// src/components/HeroText.astro
+// Hero variant: text-only. No hero image / video — oversized tagline,
+// subtitle, 2-CTA row, optional trust row, location badge.
+//
+// Chosen by layout-strategist when the business has no quality hero
+// photos (`media.heroImages.filter(quality >= threshold).length === 0`).
+// Typography scale bumps up one step to fill the space the missing
+// image leaves (spec: 2026-04-17-template-section-variants-library).
+//
+// Props contract mirrors Hero.astro so variants are drop-in
+// interchangeable from index.astro's dispatcher.
+import { client, hero, contact, location, theme, testimonials, brand } from '../lib/data';
+import BrandName from './BrandName.astro';
+import { brandify } from '../lib/brandify';
+
+const heroTagline = hero?.heroTagline || client.name;
+const heroSubtitle = hero?.heroSubtitle || '';
+const marqueeItems = theme?.marqueeItems || [];
+
+// Hero stats — identical rules to Hero.astro so the trust row reads the same
+const ratingValue = testimonials?.averageRating ? String(testimonials.averageRating) : '';
+const reviewCount = testimonials?.reviewCount ? String(testimonials.reviewCount) : '';
+const foundingYear = parseInt(String(client.foundingYear || '0'), 10);
+const hasHeroStats = !!(ratingValue || reviewCount || (foundingYear > 1900));
+
+// Location badge — same rules as Hero.astro
+const serviceArea = client.serviceArea || '';
+const city = location?.city || '';
+const state = location?.state || '';
+const badgeText = serviceArea || (city ? `Serving ${city}${state ? ` & ${state}` : ''}` : '');
+
+// Contact for CTAs
+const phone = contact?.phoneForTel || contact?.phone || '';
+const phoneClean = phone.replace(/\D/g, '');
+
+// CTA resolution matches Hero.astro exactly so heroCta prop is a drop-in override
+const { heroCta } = Astro.props as { heroCta?: { text: string; href: string }; variant?: string | number };
+const heroCTAData = hero?.cta;
+const primaryHref = heroCta?.href || heroCTAData?.href || (phoneClean ? `sms:+1${phoneClean}` : '#contact');
+const primaryText = heroCta?.text || heroCTAData?.text || (phoneClean ? 'Text Us' : 'Get in Touch');
+
+// Secondary CTA — prefer hero.json secondaryCta, otherwise default based on
+// whether the site has a Services section. Same rule as Hero.astro.
+const heroSecondaryCta = (hero as { secondaryCta?: { text?: string; href?: string } } | undefined)?.secondaryCta;
+const sectionOrder: string[] = Array.isArray(theme?.sectionOrder) ? theme.sectionOrder : [];
+const hasServicesSection = sectionOrder.includes('services');
+const secondaryHref = heroSecondaryCta?.href || (hasServicesSection ? '#services' : '#contact');
+const secondaryText = heroSecondaryCta?.text || (hasServicesSection ? 'Our Services' : 'Contact');
+---
+<section
+  class="hero hero--text"
+  id="hero"
+  data-hero-style="text"
+  data-tour="hero"
+>
+  <div class="container hero-container">
+    <div class="hero-content">
+      {/* Badge pill */}
+      {badgeText && (
+        <div class="hero-badge reveal-up">
+          <span class="hero-badge-dot" aria-hidden="true"></span>
+          <span>{badgeText}</span>
+        </div>
+      )}
+
+      {/* Tagline — oversized for text-only variant */}
+      <h1 class="hero-tagline reveal-up">{heroTagline}</h1>
+
+      {/* Subtitle */}
+      {heroSubtitle && (
+        <p class="hero-subtitle reveal-up" set:html={brandify(heroSubtitle, client.name, brand)} />
+      )}
+
+      {/* Optional trust row — rating, review count, founding year */}
+      {hasHeroStats && (
+        <div class="hero-stats reveal-up">
+          {ratingValue && (
+            <span class="hero-stat">
+              <span class="hero-stat-star" aria-hidden="true">★</span>
+              <span class="hero-stat-value" data-count-to={ratingValue} data-count-delay="450">0</span>
+            </span>
+          )}
+          {reviewCount && (
+            <>
+              {ratingValue && <span class="hero-stat-sep" aria-hidden="true">&middot;</span>}
+              <span class="hero-stat">
+                <span class="hero-stat-value" data-count-to={reviewCount} data-count-suffix="+" data-count-delay="450">0</span>
+                <span class="hero-stat-label">Reviews</span>
+              </span>
+            </>
+          )}
+          {foundingYear > 1900 && (
+            <>
+              {(ratingValue || reviewCount) && <span class="hero-stat-sep" aria-hidden="true">&middot;</span>}
+              <span class="hero-stat">
+                <span class="hero-stat-label">Since</span>
+                <span class="hero-stat-value">{foundingYear}</span>
+              </span>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* 2-CTA row */}
+      <div class="hero-ctas reveal-up">
+        <a href={primaryHref} class="btn btn--primary">{primaryText}</a>
+        <a href={secondaryHref} class="btn btn--ghost">{secondaryText}</a>
+      </div>
+
+      {/* Open/closed + location */}
+      <div class="hero-meta reveal-up">
+        <div class="open-badge" id="open-badge">
+          <span class="badge-text">Loading hours...</span>
+        </div>
+        {location?.city && (
+          <a href={location.mapLink || '#'} class="hero-location">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+            <span>{location.address ? `${location.address}, ` : ''}{location.city}{location.state ? `, ${location.state}` : ''}{location.zip ? ` ${location.zip}` : ''}</span>
+          </a>
+        )}
+      </div>
+    </div>
+  </div>
+
+  {/* Marquee strip at bottom (same affordance as other hero variants) */}
+  {marqueeItems.length > 0 && (
+    <div class="hero-marquee-wrap">
+      <div class="marquee-container">
+        <div class="marquee">
+          {[...marqueeItems, ...marqueeItems].map((item: string, i: number) => (
+            <span class="marquee-item">
+              {i > 0 && <span class="marquee-dot" aria-hidden="true">&bull;</span>}
+              {item}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  )}
+</section>
+
+<style>
+  /* ===================================================================
+     Hero — Text variant (no image)
+     Oversized tagline, centered layout, typography does the heavy lifting.
+     All colors come from CSS custom properties so dark mode parity is
+     automatic via the theme token swap in tokens.css.
+     =================================================================== */
+  .hero {
+    position: relative;
+    color: var(--text);
+    overflow: hidden;
+    min-height: 80vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .hero--text {
+    background: linear-gradient(180deg, var(--surface) 0%, var(--bg, var(--background)) 100%);
+    text-align: center;
+  }
+
+  .hero-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: var(--gap-lg, 2rem);
+    flex: 1;
+    padding-top: clamp(5rem, 3.5rem + 4vw, 7rem);
+    padding-bottom: var(--gap-xl, 3rem);
+    align-items: center;
+  }
+
+  .hero-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap, 1rem);
+    z-index: 2;
+    align-items: center;
+    text-align: center;
+    max-width: 960px;
+  }
+
+  /* ── Badge pill ─────────────────────────────────────────────── */
+  .hero-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.375rem 1rem;
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
+    border-radius: var(--radius-full, 9999px);
+    font-size: var(--caption-size, 0.75rem);
+    font-weight: 600;
+    color: var(--accent);
+    letter-spacing: var(--tracking-wide, 0.08em);
+    text-transform: uppercase;
+    width: fit-content;
+  }
+
+  .hero-badge-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--accent);
+    animation: pulse-badge 2s ease-in-out infinite;
+  }
+
+  @keyframes pulse-badge {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.5; transform: scale(0.7); }
+  }
+
+  /* ── Tagline — oversized, centered ──────────────────────────── */
+  .hero-tagline {
+    font-family: var(--font-heading);
+    font-size: var(--mega-size, clamp(3.5rem, 2rem + 7vw, 9rem));
+    font-weight: 700;
+    line-height: var(--line-height-tight, 1.1);
+    letter-spacing: var(--tracking-tight, -0.02em);
+    color: var(--text);
+    max-width: 14ch;
+    text-align: center;
+    position: relative;
+  }
+
+  /* Accent underline on tagline */
+  .hero-tagline::after {
+    content: '';
+    display: block;
+    width: 60px;
+    height: 3px;
+    background: var(--accent);
+    border-radius: 2px;
+    margin: 0.75rem auto 0;
+  }
+
+  /* ── Subtitle ───────────────────────────────────────────────── */
+  .hero-subtitle {
+    font-size: var(--lead-size, clamp(1.125rem, 1rem + 0.5vw, 1.375rem));
+    line-height: var(--line-height-body, 1.6);
+    color: var(--textMuted, var(--text));
+    max-width: 50ch;
+    text-align: center;
+  }
+
+  /* ── Trust row ──────────────────────────────────────────────── */
+  .hero-stats {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .hero-stat {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-weight: 600;
+  }
+
+  .hero-stat-star {
+    color: var(--accent);
+    font-size: 1.1em;
+  }
+
+  .hero-stat-value {
+    font-family: var(--font-heading);
+    color: var(--accent);
+    font-size: 1rem;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .hero-stat-label {
+    font-size: var(--small-size, 0.875rem);
+    opacity: 0.7;
+  }
+
+  .hero-stat-sep {
+    color: var(--textMuted, var(--text));
+    opacity: 0.3;
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+
+  /* ── CTAs ────────────────────────────────────────────────────── */
+  .hero-ctas {
+    display: flex;
+    gap: var(--gap, 1rem);
+    flex-wrap: wrap;
+    padding-top: 0.5rem;
+    justify-content: center;
+  }
+
+  /* ── Meta (open badge + location) ───────────────────────────── */
+  .hero-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding-top: 0.5rem;
+    align-items: center;
+  }
+
+  .open-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.375rem 0.75rem;
+    border-radius: var(--radius-full, 9999px);
+    font-size: var(--small-size, 0.875rem);
+    font-weight: 600;
+    width: fit-content;
+    background: color-mix(in srgb, var(--surface) 60%, transparent);
+    border: 1px solid color-mix(in srgb, var(--border) 30%, transparent);
+  }
+
+  :global(.open-badge.open) {
+    background: var(--status-success);
+    color: #fff;
+    border: none;
+  }
+
+  :global(.open-badge.open)::before {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #fff;
+    animation: pulse-dot 2s ease-in-out infinite;
+  }
+
+  :global(.open-badge.open-24-7) {
+    background: color-mix(in srgb, var(--status-success) 15%, transparent);
+    color: var(--status-success);
+    border: 1px solid color-mix(in srgb, var(--status-success) 30%, transparent);
+    font-size: 1rem;
+    padding: 0.5rem 1rem;
+  }
+
+  :global(.open-badge.open-24-7)::before {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--status-success);
+    animation: pulse-dot 2s ease-in-out infinite;
+  }
+
+  :global(.open-badge.closed) {
+    background: color-mix(in srgb, var(--surface) 80%, transparent);
+    color: var(--textMuted, var(--text));
+  }
+
+  @keyframes pulse-dot {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.4; transform: scale(0.8); }
+  }
+
+  .hero-location {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: var(--small-size, 0.875rem);
+    opacity: 0.7;
+    text-decoration: none;
+    color: inherit;
+    transition: opacity var(--duration-fast, 0.2s) ease;
+  }
+
+  .hero-location:hover {
+    opacity: 1;
+    text-decoration: none;
+  }
+
+  /* ── Marquee strip at hero bottom ───────────────────────────── */
+  .hero-marquee-wrap {
+    position: relative;
+    z-index: 2;
+    border-top: 1px solid color-mix(in srgb, var(--border) 20%, transparent);
+    padding: 0.75rem 0;
+    background: color-mix(in srgb, var(--surface) 40%, transparent);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
+
+  /* ── Responsive ─────────────────────────────────────────────── */
+  @media (max-width: 640px) {
+    .hero {
+      min-height: 70vh;
+    }
+
+    .hero-ctas {
+      flex-direction: column;
+    }
+
+    .hero-ctas .btn {
+      width: 100%;
+      justify-content: center;
+    }
+
+    .hero-tagline::after {
+      width: 40px;
+    }
+  }
+
+  /* ── Reduced motion ─────────────────────────────────────────── */
+  @media (prefers-reduced-motion: reduce) {
+    .hero-badge-dot {
+      animation: none;
+    }
+  }
+</style>

--- a/src/lib/section-registry.ts
+++ b/src/lib/section-registry.ts
@@ -29,6 +29,7 @@ export const DEFAULT_COMPONENTS: Record<string, string> = {
 
 /** Component variant overrides (variant string → component name) */
 export const VARIANT_OVERRIDES: Record<string, Record<string, string>> = {
+  hero: { text: 'HeroText' },
   trust: { stats: 'TrustStats' },
   contact: { 'order-visit': 'OrderVisit' },
   about: { 'author-bio': 'AuthorBio' },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import StickyHeader from '../components/StickyHeader.astro';
 import Hero from '../components/Hero.astro';
+import HeroText from '../components/HeroText.astro';
 import ServiceCards from '../components/ServiceCards.astro';
 import PhotoGallery from '../components/PhotoGallery.astro';
 import ProjectGallery from '../components/ProjectGallery.astro';
@@ -43,7 +44,7 @@ const hasReviews = (testimonials?.reviewCount ?? 0) > 0 || (testimonials?.averag
 
 // Component lookup by name string
 const componentMap: Record<string, any> = {
-  Hero, ServiceCards, PhotoGallery, ProjectGallery,
+  Hero, HeroText, ServiceCards, PhotoGallery, ProjectGallery,
   TrustBar, TrustStats, ProcessSteps, MenuSection,
   Reviews, FAQ, QuoteForm, OrderVisit, AboutMap,
   HoursDisplay, BeforeAfter, Differentiator, Marquee,


### PR DESCRIPTION
Closes #80 (PR 1 of 6 — spec: [`docs/superpowers/specs/2026-04-17-template-section-variants-library.md`](https://github.com/ziamade/ziamade-platform/blob/master/docs/superpowers/specs/2026-04-17-template-section-variants-library.md) in platform repo)

## Summary
- Adds `HeroText.astro` — text-only hero for clients with no quality photos
- Wires `hero.variant = "text"` → `HeroText` via existing `VARIANT_OVERRIDES` registry
- Dark mode parity from day one (uses existing CSS custom properties)
- Identical props contract to `Hero.astro` (variant is drop-in interchangeable)

## Test plan
- [ ] `npm test` — all vitest tests pass including new `section-registry.test.ts` case
- [ ] `npm run check` — no astro type errors
- [ ] `npm run build` — production build succeeds
- [ ] Manual forced-variant screenshot (Reviewer: set `theme.sections[0].variant = "text"` in a fixture and compare to default overlay hero)

## Scope deviation from spec
Spec imagines `src/components/sections/hero/index.astro` dispatcher + directory restructure. Existing code already has an equivalent name-based registry (`src/lib/section-registry.ts` + `componentMap` in `index.astro`). PR adds the variant via the existing pattern instead of restructuring — same semantics, far smaller blast radius. Engineer Lead approved this deviation at dispatch time.

## Not in this PR (deferred to later PRs in #80 series)
- Reviews/Feature, FAQ/TwoColumn, CTA/Card+Inline, Hero/Split (separate PRs per spec ship order)
- Layout-strategist selection rule (`media.heroImages.filter(quality >= threshold).length === 0` → `text`) — lands in ziamade-platform repo, separate PR per spec
- Validator whitelist update in ziamade-platform — separate PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added a text-only "text" variant for hero sections featuring centered oversized taglines, optional subtitles, trust indicators (ratings, review counts, founding years), dual-action CTAs, location information, and optional marquee strips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->