### PR TITLE
fix(ci): install workspace deps before visual-regression fixture build

### DIFF
--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -32,7 +32,9 @@ jobs:
         run: |
           cd /tmp
           git clone --depth 1 https://x-access-token:${{ secrets.PLATFORM_READ_TOKEN }}@github.com/ziamade/ziamade-platform.git
-          cd ziamade-platform/packages/pipeline
+          cd ziamade-platform
+          npm ci
+          cd packages/pipeline
           TEMPLATE_DIR=$GITHUB_WORKSPACE npx tsx scripts/build-from-fixture.ts ${{ matrix.fixture }}
           cd build/${{ matrix.fixture }} && npm ci && npx astro build
 


### PR DESCRIPTION
Closes #84

## Summary
Inserts `cd /tmp/ziamade-platform && npm ci` in the visual-regression workflow so the `/tmp` clone of ziamade-platform has workspace packages resolved before `build-from-fixture.ts` runs. Fixes the `ERR_MODULE_NOT_FOUND: Cannot find package '@ziamade/shared'` error that's been red on every PR for ~10 days.

Alternative fixes (publish @ziamade/pipeline as artifact, inline fixtures in this repo) deferred — this is the least-invasive fix that restores the signal.

## Test plan
- [ ] This PR's own visual-regression CI run passes (or surfaces visual diffs instead of failing at install step)
- [ ] YAML valid — no workflow parse error on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the visual testing workflow to optimize dependency installation and build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->