### PR TITLE
fix(reviews): add :focus-visible rules for CTA and count link

### DIFF
--- a/src/components/Reviews.astro
+++ b/src/components/Reviews.astro
@@ -159,7 +159,9 @@ const hasData = (reviewCount && reviewCount > 0) || (averageRating && averageRat
   }
 
   .reviews-cta:focus-visible,
-  .reviews-count-text a:focus-visible {
+  .reviews-cta-btn:focus-visible,
+  .reviews-count-text a:focus-visible,
+  .reviews-count a:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
   }


### PR DESCRIPTION
Closes #83

## Summary
Adds the two missing `:focus-visible` rules on Reviews.astro flagged by `focus-visible.test.ts`:
- `.reviews-cta-btn:focus-visible`
- `.reviews-count a:focus-visible`

Accessibility regression — got dropped during a prior Reviews refactor. Pattern matches existing focus-visible rules in other components (`outline: 2px solid var(--accent); outline-offset: 2px`).

## Test plan
- [x] `npx vitest run src/lib/__tests__/focus-visible.test.ts` — 2 failures -> 0 (19/19 passing)
- [x] `npm test` — overall suite moves forward by 2 passing cases (was 4 failed / 148 passed on main, now 2 failed / 150 passed; the 2 remaining failures are pre-existing `version-consistency.test.ts` issues, unrelated)
- [x] `npm run check` — no new type errors in Reviews.astro (pre-existing errors elsewhere unchanged)