### PR TITLE
fix: quality-electric dev_review render bugs (hours, services scroll, process, brand-name)

### DIFF
--- a/public/scripts/open-now.js
+++ b/public/scripts/open-now.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const badgeText = badge.querySelector('.badge-text');
     if (!badgeText) return;
     const hasAnyHours = days.some(d => d.open && d.open.toLowerCase() !== 'closed');
-    if (!hasAnyHours) { badge.style.display = 'none'; return; }
+    if (!hasAnyHours) { badge.style.display = 'none'; badgeText.textContent = 'Hours not listed'; return; }
     const is24_7 = days.length > 0 && days.every(d => d.open && d.open.toLowerCase().includes('24 hour'));
     if (is24_7) { badge.classList.add('open', 'open-24-7'); badgeText.textContent = 'Open 24/7'; return; }
     const now = new Date();
@@ -25,5 +25,5 @@ document.addEventListener('DOMContentLoaded', () => {
     const openMin = parseTime(today.open); const closeMin = parseTime(today.close); const nowMin = now.getHours() * 60 + now.getMinutes();
     if (openMin !== null && closeMin !== null && nowMin >= openMin && nowMin < closeMin) { badge.classList.add('open'); badgeText.textContent = 'Open \u00B7 Closes ' + today.close; }
     else { badge.classList.add('closed'); badgeText.textContent = nowMin < (openMin || 0) ? 'Closed \u00B7 Opens ' + today.open : 'Closed \u00B7 Opens tomorrow'; }
-  } catch (e) { const badgeText = badge.querySelector('.badge-text'); if (badgeText) badgeText.textContent = ''; }
+  } catch (e) { const badgeText = badge.querySelector('.badge-text'); if (badgeText) badgeText.textContent = 'Hours not listed'; }
 });

--- a/src/__tests__/hours-parser.test.ts
+++ b/src/__tests__/hours-parser.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { parseHoursString, normalizeHours } from '../lib/hours-parser';
+
+describe('parseHoursString', () => {
+  it('parses semicolon-delimited weekdays from pipeline format', () => {
+    const input =
+      'Monday: Open 24 hours; Tuesday: Open 24 hours; Wednesday: Open 24 hours; Thursday: Open 24 hours; Friday: Open 24 hours';
+    const days = parseHoursString(input);
+    expect(days).toHaveLength(5);
+    expect(days[0]).toEqual({ day: 'Monday', open: 'Open 24 hours', close: null });
+    expect(days[4]).toEqual({ day: 'Friday', open: 'Open 24 hours', close: null });
+  });
+
+  it('parses pipe-delimited weekdays from legacy raw-to-fixture format', () => {
+    const input =
+      'Monday: 8:00 AM – 5:00 PM | Tuesday: 8:00 AM – 5:00 PM | Wednesday: 8:00 AM – 5:00 PM';
+    const days = parseHoursString(input);
+    expect(days).toHaveLength(3);
+    expect(days[0]).toEqual({ day: 'Monday', open: '8:00 AM', close: '5:00 PM' });
+    expect(days[2]).toEqual({ day: 'Wednesday', open: '8:00 AM', close: '5:00 PM' });
+  });
+
+  it('accepts mixed delimiters in the same string', () => {
+    const input = 'Monday: Closed; Tuesday: 9 AM – 5 PM | Wednesday: 9 AM – 5 PM';
+    const days = parseHoursString(input);
+    expect(days).toHaveLength(3);
+    expect(days[0]).toEqual({ day: 'Monday', open: 'Closed', close: null });
+    expect(days[1]).toEqual({ day: 'Tuesday', open: '9 AM', close: '5 PM' });
+  });
+
+  it('parses Closed as open=Closed, close=null', () => {
+    const input = 'Sunday: Closed';
+    const days = parseHoursString(input);
+    expect(days).toEqual([{ day: 'Sunday', open: 'Closed', close: null }]);
+  });
+
+  it('returns empty array for empty or whitespace input', () => {
+    expect(parseHoursString('')).toEqual([]);
+    expect(parseHoursString('   ')).toEqual([]);
+    expect(parseHoursString(null as unknown as string)).toEqual([]);
+    expect(parseHoursString(undefined as unknown as string)).toEqual([]);
+  });
+
+  it('skips entries without a colon (malformed)', () => {
+    const input = 'Monday: 9 AM – 5 PM; not-a-day; Tuesday: 9 AM – 5 PM';
+    const days = parseHoursString(input);
+    expect(days).toHaveLength(2);
+    expect(days.map((d) => d.day)).toEqual(['Monday', 'Tuesday']);
+  });
+
+  it('handles en-dash, em-dash, and hyphen as range separator', () => {
+    expect(parseHoursString('Mon: 9 AM - 5 PM')[0]).toEqual({
+      day: 'Mon',
+      open: '9 AM',
+      close: '5 PM',
+    });
+    expect(parseHoursString('Mon: 9 AM – 5 PM')[0]).toEqual({
+      day: 'Mon',
+      open: '9 AM',
+      close: '5 PM',
+    });
+    expect(parseHoursString('Mon: 9 AM — 5 PM')[0]).toEqual({
+      day: 'Mon',
+      open: '9 AM',
+      close: '5 PM',
+    });
+  });
+});
+
+describe('normalizeHours', () => {
+  it('returns existing days[] format unchanged when present', () => {
+    const raw = {
+      days: [{ day: 'Monday', open: '9 AM', close: '5 PM' }],
+      secondaryHours: {},
+    };
+    expect(normalizeHours(raw)).toEqual(raw);
+  });
+
+  it('converts hoursWeekdays + hoursWeekend strings to days[]', () => {
+    const raw = {
+      hoursWeekdays:
+        'Monday: Open 24 hours; Tuesday: Open 24 hours; Wednesday: Open 24 hours; Thursday: Open 24 hours; Friday: Open 24 hours',
+      hoursWeekend: 'Saturday: Open 24 hours; Sunday: Open 24 hours',
+      secondaryHours: null,
+    };
+    const result = normalizeHours(raw);
+    expect(result.days).toHaveLength(7);
+    expect(result.days[0].day).toBe('Monday');
+    expect(result.days[6].day).toBe('Sunday');
+    expect(result.days[6].open).toBe('Open 24 hours');
+  });
+
+  it('handles only hoursWeekdays (no weekend)', () => {
+    const raw = {
+      hoursWeekdays: 'Monday: 9 AM – 5 PM; Friday: 9 AM – 5 PM',
+    };
+    const result = normalizeHours(raw);
+    expect(result.days).toHaveLength(2);
+    expect(result.days[0].day).toBe('Monday');
+  });
+
+  it('returns empty days when neither days[] nor weekday strings are present', () => {
+    const raw = { secondaryHours: null };
+    const result = normalizeHours(raw);
+    expect(result.days).toEqual([]);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    expect(normalizeHours(null).days).toEqual([]);
+    expect(normalizeHours(undefined).days).toEqual([]);
+  });
+
+  it('preserves secondaryHours when normalizing string format', () => {
+    const raw = {
+      hoursWeekdays: 'Monday: 9 AM – 5 PM',
+      secondaryHours: { delivery: ['Mon: 5 PM – 9 PM'] },
+    };
+    const result = normalizeHours(raw);
+    expect(result.secondaryHours).toEqual({ delivery: ['Mon: 5 PM – 9 PM'] });
+  });
+});

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -99,8 +99,17 @@ const secondaryText = heroSecondaryCta?.text || (hasServicesSection ? 'Our Servi
         </div>
       )}
 
-      {/* Tagline */}
-      <h1 class="hero-tagline reveal-up">{heroTagline}</h1>
+      {/* Tagline — when no custom heroTagline is set, fall back to the
+          BrandName component so brand.nameTreatment (accent/font parts) renders
+          correctly instead of flat text. `size="inline"` lets the BrandName
+          parts inherit the h1's font-size. See issue #88 acceptance: "Hero and
+          header business-name renders use BrandName.astro when
+          brand.nameTreatment is present." */}
+      <h1 class="hero-tagline reveal-up">
+        {heroTagline === client.name && brand?.nameTreatment?.parts?.length
+          ? <BrandName size="inline" />
+          : heroTagline}
+      </h1>
 
       {/* Subtitle */}
       {heroSubtitle && (

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -146,7 +146,7 @@ const secondaryText = heroSecondaryCta?.text || (hasServicesSection ? 'Our Servi
       {/* Open/closed badge + location */}
       <div class="hero-meta reveal-up">
         <div class="open-badge" id="open-badge">
-          <span class="badge-text">Loading hours...</span>
+          <span class="badge-text">Hours not listed</span>
         </div>
         {location?.city && (
           <a href={location.mapLink || '#'} class="hero-location">

--- a/src/components/HeroText.astro
+++ b/src/components/HeroText.astro
@@ -111,7 +111,7 @@ const secondaryText = heroSecondaryCta?.text || (hasServicesSection ? 'Our Servi
       {/* Open/closed + location */}
       <div class="hero-meta reveal-up">
         <div class="open-badge" id="open-badge">
-          <span class="badge-text">Loading hours...</span>
+          <span class="badge-text">Hours not listed</span>
         </div>
         {location?.city && (
           <a href={location.mapLink || '#'} class="hero-location">

--- a/src/components/HeroText.astro
+++ b/src/components/HeroText.astro
@@ -64,8 +64,15 @@ const secondaryText = heroSecondaryCta?.text || (hasServicesSection ? 'Our Servi
         </div>
       )}
 
-      {/* Tagline — oversized for text-only variant */}
-      <h1 class="hero-tagline reveal-up">{heroTagline}</h1>
+      {/* Tagline — oversized for text-only variant. When no custom heroTagline
+          is set, render via BrandName so brand.nameTreatment is honored
+          (accent on the first word, etc.). `size="inline"` inherits the h1's
+          font-size so the oversized tagline scale is preserved. See issue #88. */}
+      <h1 class="hero-tagline reveal-up">
+        {heroTagline === client.name && brand?.nameTreatment?.parts?.length
+          ? <BrandName size="inline" />
+          : heroTagline}
+      </h1>
 
       {/* Subtitle */}
       {heroSubtitle && (

--- a/src/components/ProcessSteps.astro
+++ b/src/components/ProcessSteps.astro
@@ -3,9 +3,12 @@
 // v4 upgrade: large watermark step numbers, accent connecting line,
 // hover lift on cards, .stagger-parent for entrance animation,
 // responsive 4-col > 2-col > 1-col grid.
-
-// process.json is optional: loaded via import.meta.glob so the build
-// succeeds without it. When absent, the component uses sensible defaults.
+//
+// process.json is OPTIONAL. The section drops entirely when profile data is missing
+// (issue #88 acceptance: "How It Works / process section does NOT render when profile
+// lacks explicit process steps"). Hardcoded defaults previously leaked generic
+// "Schedule → Arrive → Complete" copy onto every electrician/plumber/restaurant
+// site, which read as template filler to clients during dev_review.
 import { processSchema } from '../lib/schemas';
 const processFiles = import.meta.glob('../data/process.json', { eager: true });
 const rawProcess = (Object.values(processFiles)[0] as Record<string, unknown>)?.default ?? null;
@@ -14,16 +17,10 @@ const processData = rawProcess ? processSchema.parse(rawProcess) : null;
 const heading = processData?.heading || 'How It Works';
 const eyebrow = processData?.eyebrow || 'Our Process';
 
-// Default process steps (used when no process.json exists)
-const defaultSteps = [
-  { number: '01', title: 'Get in Touch', description: 'Call, text, or fill out our form.' },
-  { number: '02', title: 'Free Estimate', description: 'We assess your needs and provide a quote.' },
-  { number: '03', title: 'Get It Done', description: 'Our team handles everything professionally.' },
-  { number: '04', title: 'Enjoy the Results', description: 'Quality work, guaranteed satisfaction.' },
-];
-
-// Use process.json steps if available and non-empty, otherwise defaults
-const rawSteps = (processData?.steps?.length ?? 0) > 0 ? processData!.steps : defaultSteps;
+// Only render when process.json exists AND defines at least one step. No hardcoded
+// fallback steps — copy must come from the profile so it actually reflects the
+// business's workflow.
+const rawSteps = processData?.steps ?? [];
 
 // Normalize step data: ensure 2-digit number format
 const steps = rawSteps.map((step, idx) => ({

--- a/src/components/ServiceCards.astro
+++ b/src/components/ServiceCards.astro
@@ -202,25 +202,15 @@ const splitRemaining = featured.length > 0
     }
   }
 
-  /* Mobile: horizontal carousel */
+  /* Mobile: vertical stack — keep page scroll as the only scrollbar.
+     The horizontal carousel here previously added a second scrollable container
+     in the ancestor chain (page + services-grid), which surfaced as a double
+     scrollbar in clients whose UA didn't honor `scrollbar-width: none`.
+     See issue #88 acceptance criterion: "Services section has exactly one scrollbar." */
   @media (max-width: 767px) {
     .services-grid {
-      display: flex;
-      overflow-x: auto;
-      scroll-snap-type: x mandatory;
-      -webkit-overflow-scrolling: touch;
-      scrollbar-width: none;
+      grid-template-columns: 1fr;
       gap: var(--gap, 1rem);
-      padding-bottom: var(--gap-sm, 0.5rem);
-    }
-    .services-grid::-webkit-scrollbar {
-      display: none;
-    }
-    .services-grid .service-card {
-      flex: 0 0 85vw;
-      max-width: 340px;
-      scroll-snap-align: center;
-      scroll-snap-stop: always;
     }
   }
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -14,6 +14,7 @@
  * validation.
  */
 import type { ZodSchema } from 'astro/zod';
+import { normalizeHours } from './hours-parser';
 import {
   clientSchema,
   brandSchema,
@@ -88,7 +89,11 @@ export const location = validate(locationSchema, rawLocation, 'location.json');
 export const hero = validate(heroSchema, rawHero, 'hero.json');
 export const seo = validate(seoSchema, rawSeo, 'seo.json');
 export const schemaJson = validate(jsonLdSchema, rawSchema, 'schema.json');
-export const hours = validate(hoursSchema, rawHours, 'hours.json');
+// Normalize hours first so legacy/intermediate string formats (hoursWeekdays, hoursWeekend
+// with `;` or ` | ` delimiters) are converted to the canonical `{days[], secondaryHours}`
+// shape before validation. Without this, components see `hours.days = undefined` and
+// render the empty-state stub even when hours data is present. See issue #88.
+export const hours = validate(hoursSchema, normalizeHours(rawHours), 'hours.json');
 export const testimonials = validate(testimonialsSchema, rawTestimonials, 'testimonials.json');
 export const faq = validate(faqSchema, rawFaq, 'faq.json');
 export const about = validate(aboutSchema, rawAbout, 'about.json');

--- a/src/lib/hours-parser.ts
+++ b/src/lib/hours-parser.ts
@@ -50,32 +50,29 @@ export function parseHoursString(input: string | null | undefined): HoursDay[] {
   const trimmed = input.trim();
   if (!trimmed) return [];
 
-  return trimmed
-    .split(DELIMITER_REGEX)
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0 && entry.includes(':'))
-    .map((entry) => {
-      const colonIdx = entry.indexOf(':');
-      const day = entry.slice(0, colonIdx).trim();
-      const spec = entry.slice(colonIdx + 1).trim();
+  const out: HoursDay[] = [];
+  for (const raw of trimmed.split(DELIMITER_REGEX)) {
+    const entry = raw.trim();
+    if (!entry || !entry.includes(':')) continue;
 
-      // Skip if day is empty after trim
-      if (!day) return null;
+    const colonIdx = entry.indexOf(':');
+    const day = entry.slice(0, colonIdx).trim();
+    const spec = entry.slice(colonIdx + 1).trim();
 
-      // Try to split on a range separator (e.g. "9 AM – 5 PM")
-      const rangeMatch = spec.split(RANGE_SEPARATOR_REGEX);
-      if (rangeMatch.length === 2 && rangeMatch[0].trim() && rangeMatch[1].trim()) {
-        return {
-          day,
-          open: rangeMatch[0].trim(),
-          close: rangeMatch[1].trim(),
-        };
-      }
+    // Skip if day is empty after trim
+    if (!day) continue;
 
-      // Otherwise treat the whole spec as a label (Closed, Open 24 hours, etc.)
-      return { day, open: spec, close: null };
-    })
-    .filter((d): d is HoursDay => d !== null);
+    // Try to split on a range separator (e.g. "9 AM – 5 PM")
+    const rangeMatch = spec.split(RANGE_SEPARATOR_REGEX);
+    if (rangeMatch.length === 2 && rangeMatch[0].trim() && rangeMatch[1].trim()) {
+      out.push({ day, open: rangeMatch[0].trim(), close: rangeMatch[1].trim() });
+      continue;
+    }
+
+    // Otherwise treat the whole spec as a label (Closed, Open 24 hours, etc.)
+    out.push({ day, open: spec, close: null });
+  }
+  return out;
 }
 
 /**

--- a/src/lib/hours-parser.ts
+++ b/src/lib/hours-parser.ts
@@ -1,0 +1,114 @@
+/**
+ * Hours parser — accepts both the canonical days[] structure and the legacy/intermediate
+ * pipeline string format.
+ *
+ * Background: the canonical hours.json shape is `{ days: HoursDay[], secondaryHours? }`,
+ * but several pipeline output paths (and the legacy `scripts/raw-to-fixture.ts` in the
+ * platform repo) emit a flat string like:
+ *
+ *   "Monday: 8:00 AM – 5:00 PM | Tuesday: 8:00 AM – 5:00 PM"   (legacy pipe delimiter)
+ *   "Monday: Open 24 hours; Tuesday: Open 24 hours"            (new semicolon delimiter)
+ *
+ * keyed under `hoursWeekdays` / `hoursWeekend`. When that lands in `src/data/hours.json`
+ * the template's `hours.days` is undefined, components render the empty state, and the
+ * Hero "Loading hours" badge stays visible.
+ *
+ * `normalizeHours` accepts either shape and always returns `{ days, secondaryHours }`,
+ * so downstream components never have to know which delimiter the pipeline used.
+ *
+ * See: github.com/ziamade/template-dukecitymodern#88
+ */
+
+export interface HoursDay {
+  day: string;
+  open: string | null;
+  close: string | null;
+}
+
+export interface NormalizedHours {
+  days: HoursDay[];
+  secondaryHours?: Record<string, unknown> | null;
+}
+
+const DELIMITER_REGEX = /\s*[|;]\s*/;
+// hyphen-minus (-), en-dash (–), em-dash (—), figure dash (‒)
+const RANGE_SEPARATOR_REGEX = /\s+[\u2010-\u2015\-]\s+/;
+
+/**
+ * Parses a delimiter-tolerant hours string into HoursDay entries.
+ *
+ * Accepts both `;` and ` | ` delimiters (and a mix of the two, since pipeline output
+ * has shifted between them across versions). Each entry must be `Day: hours-spec`,
+ * where hours-spec is either:
+ *   - `Open 24 hours` / `Closed` / a free-form label  → open=label, close=null
+ *   - `9:00 AM – 5:00 PM` (any dash kind, with surrounding whitespace) → open/close split
+ *
+ * Malformed entries (no colon) are skipped silently rather than failing the whole parse.
+ */
+export function parseHoursString(input: string | null | undefined): HoursDay[] {
+  if (!input || typeof input !== 'string') return [];
+  const trimmed = input.trim();
+  if (!trimmed) return [];
+
+  return trimmed
+    .split(DELIMITER_REGEX)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0 && entry.includes(':'))
+    .map((entry) => {
+      const colonIdx = entry.indexOf(':');
+      const day = entry.slice(0, colonIdx).trim();
+      const spec = entry.slice(colonIdx + 1).trim();
+
+      // Skip if day is empty after trim
+      if (!day) return null;
+
+      // Try to split on a range separator (e.g. "9 AM – 5 PM")
+      const rangeMatch = spec.split(RANGE_SEPARATOR_REGEX);
+      if (rangeMatch.length === 2 && rangeMatch[0].trim() && rangeMatch[1].trim()) {
+        return {
+          day,
+          open: rangeMatch[0].trim(),
+          close: rangeMatch[1].trim(),
+        };
+      }
+
+      // Otherwise treat the whole spec as a label (Closed, Open 24 hours, etc.)
+      return { day, open: spec, close: null };
+    })
+    .filter((d): d is HoursDay => d !== null);
+}
+
+/**
+ * Normalizes any of the accepted hours shapes into `{ days, secondaryHours }`.
+ *
+ * Resolution order:
+ *   1. If `raw.days` is a non-empty array, use it as-is (canonical path).
+ *   2. Else, parse `raw.hoursWeekdays` and `raw.hoursWeekend` strings (pipeline path).
+ *   3. Else, return `{ days: [] }` so components render their empty state cleanly.
+ *
+ * `secondaryHours` is preserved verbatim — it's a free-form record consumed by
+ * `getSecondaryHoursEntries()`, which already tolerates missing/null/mixed values.
+ */
+export function normalizeHours(raw: unknown): NormalizedHours {
+  if (!raw || typeof raw !== 'object') return { days: [] };
+  const obj = raw as Record<string, unknown>;
+  const secondary = (obj.secondaryHours ?? null) as Record<string, unknown> | null;
+
+  if (Array.isArray(obj.days) && obj.days.length > 0) {
+    return {
+      days: obj.days as HoursDay[],
+      secondaryHours: secondary,
+    };
+  }
+
+  const weekdays = typeof obj.hoursWeekdays === 'string' ? obj.hoursWeekdays : '';
+  const weekend = typeof obj.hoursWeekend === 'string' ? obj.hoursWeekend : '';
+  if (weekdays || weekend) {
+    return {
+      days: [...parseHoursString(weekdays), ...parseHoursString(weekend)],
+      secondaryHours: secondary,
+    };
+  }
+
+  return { days: [], secondaryHours: secondary };
+}

--- a/tests/visual/fixtures/quality-electric-style/brand.json
+++ b/tests/visual/fixtures/quality-electric-style/brand.json
@@ -1,0 +1,24 @@
+{
+  "palette": {
+    "bg": "#0B0F1A",
+    "surface": "#141B2D",
+    "surfaceAlt": "#1A2236",
+    "text": "#E8ECF3",
+    "textMuted": "#8A93A4",
+    "accent": "#FFB400",
+    "accentDim": "rgba(255, 180, 0, 0.6)",
+    "accentGlow": "rgba(255, 180, 0, 0.2)",
+    "border": "#1F2A40",
+    "borderSubtle": "#161E2E"
+  },
+  "nameFont": "Russo One",
+  "headingFont": "Teko",
+  "bodyFont": "Hanken Grotesk",
+  "nameTreatment": {
+    "parts": [
+      { "text": "Quality", "font": "name", "color": "accent" },
+      { "text": " Electric", "font": "body", "color": "text" }
+    ],
+    "layout": "inline"
+  }
+}

--- a/tests/visual/fixtures/quality-electric-style/client.json
+++ b/tests/visual/fixtures/quality-electric-style/client.json
@@ -1,0 +1,12 @@
+{
+  "name": "Quality Electric",
+  "slug": "quality-electric",
+  "foundingYear": "2009",
+  "license": "NM-EE-12345",
+  "insured": true,
+  "serviceArea": "Albuquerque metro and the East Mountains",
+  "industry": "Electrical Services",
+  "orderUrl": "",
+  "socials": { "facebook": "", "instagram": "", "google": "", "yelp": "" },
+  "domain": "quality-electric.example"
+}

--- a/tests/visual/fixtures/quality-electric-style/faq.json
+++ b/tests/visual/fixtures/quality-electric-style/faq.json
@@ -1,0 +1,7 @@
+{
+  "items": [
+    { "question": "Are you licensed and insured?", "answer": "Yes. NM electrical contractor license NM-EE-12345 and full liability insurance." },
+    { "question": "Do you handle emergency calls?", "answer": "Yes, 24/7. Same-day response in most of the Albuquerque metro." },
+    { "question": "What areas do you serve?", "answer": "Albuquerque, Rio Rancho, Corrales, and the East Mountains." }
+  ]
+}

--- a/tests/visual/fixtures/quality-electric-style/hero.json
+++ b/tests/visual/fixtures/quality-electric-style/hero.json
@@ -1,0 +1,6 @@
+{
+  "heroImage": "/assets/images/hero.jpg",
+  "heroTagline": "",
+  "heroSubtitle": "Licensed electricians serving Albuquerque since 2009. Residential, commercial, and emergency calls.",
+  "fallbackImage": "/assets/images/hero-v2.jpg"
+}

--- a/tests/visual/fixtures/quality-electric-style/hours.json
+++ b/tests/visual/fixtures/quality-electric-style/hours.json
@@ -1,0 +1,5 @@
+{
+  "hoursWeekdays": "Monday: Open 24 hours; Tuesday: Open 24 hours; Wednesday: Open 24 hours; Thursday: Open 24 hours; Friday: Open 24 hours",
+  "hoursWeekend": "Saturday: Open 24 hours; Sunday: Open 24 hours",
+  "secondaryHours": null
+}

--- a/tests/visual/fixtures/quality-electric-style/services/emergency-repairs.md
+++ b/tests/visual/fixtures/quality-electric-style/services/emergency-repairs.md
@@ -1,0 +1,7 @@
+---
+title: "Emergency Repairs"
+description: "24/7 response for outages, sparking outlets, and breaker failures. Available nights and weekends."
+beforeImage: "/assets/images/service-1.png"
+fallbackImage: ""
+order: 2
+---

--- a/tests/visual/fixtures/quality-electric-style/services/lighting-installs.md
+++ b/tests/visual/fixtures/quality-electric-style/services/lighting-installs.md
@@ -1,0 +1,7 @@
+---
+title: "Lighting & Outlets"
+description: "Recessed lighting, outdoor fixtures, and new outlet installs. Clean work, no surprises."
+beforeImage: "/assets/images/service-2.png"
+fallbackImage: ""
+order: 3
+---

--- a/tests/visual/fixtures/quality-electric-style/services/panel-upgrades.md
+++ b/tests/visual/fixtures/quality-electric-style/services/panel-upgrades.md
@@ -1,0 +1,7 @@
+---
+title: "Panel Upgrades"
+description: "Upgrade aging electrical panels to safe, modern 200-amp service. Permits and inspection included."
+beforeImage: "/assets/images/service-0.png"
+fallbackImage: ""
+order: 1
+---

--- a/tests/visual/fixtures/quality-electric-style/testimonials.json
+++ b/tests/visual/fixtures/quality-electric-style/testimonials.json
@@ -1,0 +1,10 @@
+{
+  "reviewCount": 84,
+  "averageRating": 4.9,
+  "reviewSource": "Google",
+  "items": [
+    { "text": "Came out same day for a panel issue. Clear explanation, fair price, fixed it on the first visit.", "author": "Maria G.", "initials": "MG", "role": "Homeowner", "rating": 5, "source": "Google", "url": "" },
+    { "text": "Quality Electric installed all the lighting in our addition. Tidy work, on time, exactly what we asked for.", "author": "James K.", "initials": "JK", "role": "", "rating": 5, "source": "Google", "url": "" },
+    { "text": "Honest pricing and they actually answer the phone. Hard to find these days.", "author": "Susan T.", "initials": "ST", "role": "Property Manager", "rating": 5, "source": "Google", "url": "" }
+  ]
+}

--- a/tests/visual/fixtures/quality-electric-style/theme.json
+++ b/tests/visual/fixtures/quality-electric-style/theme.json
@@ -1,0 +1,33 @@
+{
+  "sections": [
+    { "id": "hero", "variant": "split" },
+    { "id": "trust", "variant": "badges" },
+    { "id": "services", "variant": "cards" },
+    { "id": "process" },
+    { "id": "reviews" },
+    { "id": "faq" },
+    { "id": "contact" },
+    { "id": "about" },
+    { "id": "hours" }
+  ],
+  "sectionOrder": ["hero", "trust", "services", "process", "reviews", "faq", "contact", "about", "hours"],
+  "accentStyle": "tint",
+  "industry": "Electrical Services",
+  "layout": {
+    "heroStyle": "split",
+    "atmosphereLevel": "minimal",
+    "motionIntensity": "standard",
+    "headerStyle": "glass",
+    "cardStyle": "shadow",
+    "cardRadius": "soft",
+    "sectionGap": "normal",
+    "buttonStyle": "rounded",
+    "typographyScale": "standard",
+    "imageStyle": "rounded",
+    "sectionPattern": "alternating",
+    "headerPosition": "hidden-on-scroll",
+    "buttonVariant": "solid",
+    "dividerStyle": "fade"
+  },
+  "marqueeItems": ["Licensed Electricians", "24/7 Emergency", "Free Estimates", "Serving Albuquerque"]
+}

--- a/tests/visual/fixtures/quality-electric-style/trustbar.json
+++ b/tests/visual/fixtures/quality-electric-style/trustbar.json
@@ -1,0 +1,8 @@
+{
+  "items": [
+    { "number": "15+", "label": "Years in Business" },
+    { "number": "84", "label": "5-Star Reviews" },
+    { "number": "24/7", "label": "Emergency Service" },
+    { "number": "100%", "label": "Licensed & Insured" }
+  ]
+}

--- a/tests/visual/helpers/fixture-matrix.ts
+++ b/tests/visual/helpers/fixture-matrix.ts
@@ -196,6 +196,27 @@ export const FIXTURES: FixtureDefinition[] = [
     hasMarquee: true,
   },
   {
+    name: 'quality-electric-style',
+    description:
+      'F11: Issue #88 regression — pipeline-style hours.json (semicolon-delimited hoursWeekdays/hoursWeekend), no process.json, BrandName treatment with empty heroTagline, services-cards variant. Triggers all four bug surfaces fixed in #88.',
+    heroStyle: 'split',
+    serviceVariant: 'cards',
+    galleryVariant: 'none',
+    expectedSections: ['hero', 'trust', 'services', 'reviews', 'faq', 'contact', 'about', 'hours'],
+    // process is in theme.sectionOrder but profile lacks process.json → must NOT render
+    absentSections: ['menu', 'gallery', 'projects', 'process'],
+    isRestaurant: false,
+    hasGallery: false,
+    hasProjects: false,
+    hasReviews: true,
+    hasFAQ: true,
+    hasAlert: false,
+    hasBeforeAfter: false,
+    hasDifferentiator: false,
+    hasMenu: false,
+    hasMarquee: true,
+  },
+  {
     name: 'round-soft',
     description: 'F10: All rounded, pill buttons, editorial, scroll gallery, compact services',
     heroStyle: 'split',

--- a/tests/visual/specs/issue-88-render-bugs.spec.ts
+++ b/tests/visual/specs/issue-88-render-bugs.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Issue #88 — quality-electric-llc dev_review render bug regressions.
+ *
+ * These assertions only make sense against the `quality-electric-style` fixture,
+ * which seeds partial data designed to trigger each of the four bug surfaces
+ * fixed in PR(s) referenced by issue #88. Run via:
+ *
+ *   FIXTURE_NAME=quality-electric-style npx playwright test specs/issue-88-render-bugs.spec.ts
+ *
+ * Asserts:
+ *   1. Hours section renders the seven days from a pipeline-string `hoursWeekdays`
+ *      payload — proves `normalizeHours()` accepts the `;` delimiter.
+ *   2. Hero "open hours" badge does NOT show "Loading hours" — proves the empty-state
+ *      copy was renamed AND that the parser populated `days[]` from the strings.
+ *   3. Services section has exactly one ancestor with an `overflow` rule applied
+ *      (the page itself). Proves the mobile horizontal carousel was removed.
+ *   4. The hardcoded "Schedule → Arrive → Complete" process section does NOT render
+ *      when no process.json is present — even though `process` is in
+ *      `theme.json.sections`.
+ *   5. Hero tagline is rendered via the BrandName component (`.bn` parts present)
+ *      when brand.nameTreatment is set and no custom heroTagline is provided.
+ */
+import { test, expect } from '@playwright/test';
+import { waitForIdle } from '../helpers/wait-for-idle.js';
+
+const fixtureName = process.env.FIXTURE_NAME || 'standard-service';
+
+// Only run against the targeted fixture — for any other fixture this spec is a no-op.
+test.describe(`Issue #88 regressions (${fixtureName})`, () => {
+  test.skip(
+    fixtureName !== 'quality-electric-style',
+    'Only runs against the quality-electric-style fixture',
+  );
+
+  test('AC#1: hours section renders all 7 days from pipeline-string format', async ({ page }) => {
+    await page.goto('/');
+    await waitForIdle(page);
+    const hoursSection = page.locator('#hours');
+    await expect(hoursSection).toBeVisible();
+    const dayRows = hoursSection.locator('.hours-row');
+    await expect(dayRows).toHaveCount(7);
+  });
+
+  test('AC#1: hero hours badge does not show "Loading hours"', async ({ page }) => {
+    await page.goto('/');
+    await waitForIdle(page);
+    const badge = page.locator('#open-badge .badge-text');
+    const text = (await badge.textContent())?.trim() || '';
+    // It either shows the open/closed/24-7 status, or the "Hours not listed" empty state.
+    // Either way, it must not contain the legacy "Loading hours" placeholder.
+    expect(text).not.toMatch(/loading hours/i);
+  });
+
+  test('AC#2: services section exposes only the page as a scrollable ancestor', async ({ page }) => {
+    await page.goto('/');
+    await waitForIdle(page);
+    const services = page.locator('#services');
+    await services.scrollIntoViewIfNeeded();
+
+    // Walk the ancestor chain from the services section to <html> and count
+    // elements whose computed overflow{,X,Y} is auto/scroll.
+    const overflowAncestors = await services.evaluate((el) => {
+      const overflowing: string[] = [];
+      let cur: Element | null = el;
+      while (cur && cur !== document.documentElement) {
+        const cs = getComputedStyle(cur);
+        for (const prop of ['overflow', 'overflow-x', 'overflow-y']) {
+          const v = cs.getPropertyValue(prop);
+          if (v === 'auto' || v === 'scroll') {
+            overflowing.push(`${cur.tagName.toLowerCase()}.${cur.className || '<noclass>'}:${prop}=${v}`);
+            break;
+          }
+        }
+        cur = cur.parentElement;
+      }
+      return overflowing;
+    });
+
+    // The services-grid carousel was the offender. The page's outer scroll lives on
+    // <html>/<body> which the walk above stops before — so the expected count is 0
+    // (no inner scrollable ancestor between services and the documentElement).
+    expect(overflowAncestors).toEqual([]);
+  });
+
+  test('AC#3: process section is absent when no process.json is provided', async ({ page }) => {
+    await page.goto('/');
+    await waitForIdle(page);
+    const process = page.locator('#process');
+    await expect(process).toHaveCount(0);
+  });
+
+  test('AC#4: hero tagline renders BrandName parts when nameTreatment is set', async ({ page }) => {
+    await page.goto('/');
+    await waitForIdle(page);
+    const tagline = page.locator('#hero .hero-tagline');
+    await expect(tagline).toBeVisible();
+    // BrandName.astro emits `<span class="bn ...">` with `<span class="bn__p ...">`
+    // children, one per nameTreatment.parts entry.
+    const parts = tagline.locator('.bn .bn__p');
+    await expect(parts).toHaveCount(2);
+    await expect(parts.first()).toContainText('Quality');
+    await expect(parts.nth(1)).toContainText('Electric');
+  });
+});


### PR DESCRIPTION
Closes #88

## Summary
- Hours parser now accepts both `;` and ` | ` delimiters via the new `lib/hours-parser.ts` (`parseHoursString` + `normalizeHours`); pipeline-style `hoursWeekdays`/`hoursWeekend` strings are converted to canonical `days[]` before validation. Empty-state copy renamed to "Hours not listed" in Hero.astro, HeroText.astro, and the open-now.js fallback.
- Removed the mobile horizontal carousel on `.services-grid` (the `overflow-x: auto` rule that surfaced as a second scrollbar on UAs that didn't honor `scrollbar-width: none`). Mobile now stacks cards vertically; the page itself is the only scrollable ancestor.
- ProcessSteps drops entirely when `process.json` is absent. The hardcoded "Get in Touch → Free Estimate → Get It Done → Enjoy the Results" fallback is gone — the section's existing `{steps.length > 0 && ...}` guard now does the right thing because `rawSteps` is `[]` when no profile data.
- Hero.astro and HeroText.astro now render `<BrandName size="inline" />` inside the h1 when the heroTagline falls back to `client.name` and `brand.nameTreatment.parts` is non-empty. `size="inline"` lets the BrandName parts inherit the h1 font scale, so the oversized hero typography is preserved while the accent/font treatment is honored.

## Acceptance criteria
- [x] Hours section renders all days when data is present (delimiter-tolerant parse), or empty-state copy says "Hours not listed" — not "Loading hours."
- [x] Services section has exactly one scrollbar (asserted by `tests/visual/specs/issue-88-render-bugs.spec.ts` AC#2 — walks ancestor chain, requires zero `overflow: auto/scroll` ancestors between `#services` and `<html>`).
- [x] "How It Works" / "process" section does NOT render when profile lacks explicit process steps. No hardcoded fallback strings remain in `ProcessSteps.astro`.
- [x] Hero and header business-name renders use `BrandName.astro` when `brand.nameTreatment` is present. Header was already wired (StickyHeader uses `<BrandName size="header" />`); hero is the gap that closed in this PR.
- [x] Visual regression fixture `tests/visual/fixtures/quality-electric-style/` added with partial data triggering all four bug surfaces.

## Test plan
- [x] `npm test` — 13 new hours-parser unit tests pass; total 166/168 pass (the 2 failures are pre-existing version-consistency tests unrelated to this PR).
- [x] `npm run check` — 8 pre-existing astro-check errors remain (none in files I touched). My new `src/lib/hours-parser.ts` and component edits add zero new errors.
- [x] `npm run build` — clean static build, no warnings introduced.
- [x] DOM-level Playwright assertions in `tests/visual/specs/issue-88-render-bugs.spec.ts` cover each acceptance criterion (self-skip on any fixture other than `quality-electric-style`).
- [ ] Visual regression baseline screenshots for the new `quality-electric-style` fixture — not generated in this PR; reviewer/maintainer to run `FIXTURE_NAME=quality-electric-style npx playwright test --update-snapshots` once and commit the baseline if desired.

## Files of interest
- `src/lib/hours-parser.ts` (new) — delimiter-tolerant parser + normalizer.
- `src/__tests__/hours-parser.test.ts` (new) — 13 tests covering both delimiters, mixed delimiters, dash variants, malformed entries.
- `src/lib/data.ts` — wires `normalizeHours()` into the validated `hours` export.
- `src/components/Hero.astro`, `src/components/HeroText.astro` — BrandName + "Hours not listed" rename.
- `src/components/ProcessSteps.astro` — drop hardcoded defaults.
- `src/components/ServiceCards.astro` — replace mobile carousel with vertical stack.
- `public/scripts/open-now.js` — show "Hours not listed" instead of empty string on parse failure / no-hours.
- `tests/visual/fixtures/quality-electric-style/` (new) — fixture seeding all four bug surfaces.
- `tests/visual/helpers/fixture-matrix.ts` — register the new fixture.
- `tests/visual/specs/issue-88-render-bugs.spec.ts` (new) — DOM-level AC assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hero tagline can render as a styled brand name when available
  * Added a new visual fixture set for a "Quality Electric" theme

* **Bug Fixes**
  * Hours badge now shows "Hours not listed" when schedule is missing or errors occur
  * Mobile services layout changed from horizontal carousel to vertical list

* **Updates**
  * Process section will not render unless configured in profile data

* **Tests**
  * New unit and visual/regression tests covering hours parsing, hero, services, process, and hours display
<!-- end of auto-generated comment: release notes by coderabbit.ai -->