### PR TITLE
fix(data): make menu + team imports optional (visual-diff CI fix) (#90)

### DIFF
--- a/src/__tests__/data-optional.test.ts
+++ b/src/__tests__/data-optional.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { menu, team } from '../lib/data';
+
+/**
+ * Issue #90: menu.json and team.json are optional client-data files.
+ * Non-restaurant fixtures (pwtint, martinezwelding) ship without menu.json;
+ * non-team fixtures (dcdrentals) ship without team.json.
+ *
+ * `src/lib/data.ts` loads them via `import.meta.glob` so the build succeeds
+ * either way. These tests guard the public contract: regardless of whether
+ * the source files exist, the exported `menu` and `team` constants always
+ * expose a safely-shaped object so consumers (MenuSection, Team) keep working.
+ */
+describe('optional menu + team data exports', () => {
+  it('menu always exposes a categories array', () => {
+    expect(menu).toBeDefined();
+    expect(Array.isArray(menu.categories)).toBe(true);
+  });
+
+  it('team always exposes an items array', () => {
+    expect(team).toBeDefined();
+    expect(Array.isArray(team.items)).toBe(true);
+  });
+});

--- a/src/__tests__/data-optional.test.ts
+++ b/src/__tests__/data-optional.test.ts
@@ -1,17 +1,39 @@
 import { describe, it, expect } from 'vitest';
-import { menu, team } from '../lib/data';
+import {
+  menu,
+  team,
+  cta,
+  book,
+  attributes,
+  googleLinks,
+} from '../lib/data';
 
 /**
- * Issue #90: menu.json and team.json are optional client-data files.
- * Non-restaurant fixtures (pwtint, martinezwelding) ship without menu.json;
- * non-team fixtures (dcdrentals) ship without team.json.
+ * Issue #90: pipeline-conditional client-data files must not break the Astro
+ * build when they're absent. Per the Pipeline Data Contract, the following
+ * files are emitted only under specific conditions:
+ *   - menu.json          — restaurants only
+ *   - team.json          — team-led businesses only
+ *   - cta.json           — authors only
+ *   - book.json          — authors only
+ *   - attributes.json    — Places v2 with attributes
+ *   - google-links.json  — only written if links exist
+ *   - verification.json  — verify-business skill / NM only (already loaded
+ *                          via `import.meta.glob` in its consumer; not
+ *                          surfaced through `src/lib/data.ts`).
  *
- * `src/lib/data.ts` loads them via `import.meta.glob` so the build succeeds
+ * `src/lib/data.ts` loads each via `import.meta.glob` so the build succeeds
  * either way. These tests guard the public contract: regardless of whether
- * the source files exist, the exported `menu` and `team` constants always
- * expose a safely-shaped object so consumers (MenuSection, Team) keep working.
+ * the source files exist, the exported constants always expose a safely-shaped
+ * object so consumers (MenuSection / Team / CTASection / BookShowcase /
+ * Reviews) keep rendering — or short-circuit cleanly — without crashing.
+ *
+ * The assertions below intentionally describe the *fallback shape* the
+ * consumer expects when the file is absent. When the file IS present (as in
+ * any fixture-backed test run), the validated/typed value strictly extends
+ * the fallback, so each assertion still holds.
  */
-describe('optional menu + team data exports', () => {
+describe('optional pipeline-conditional data exports', () => {
   it('menu always exposes a categories array', () => {
     expect(menu).toBeDefined();
     expect(Array.isArray(menu.categories)).toBe(true);
@@ -20,5 +42,37 @@ describe('optional menu + team data exports', () => {
   it('team always exposes an items array', () => {
     expect(team).toBeDefined();
     expect(Array.isArray(team.items)).toBe(true);
+  });
+
+  it('cta always exposes a defined object (consumer guards with truthy fields)', () => {
+    expect(cta).toBeDefined();
+    // CTASection.astro destructures { text, buttonText, buttonHref, enabled }
+    // and renders nothing when any are falsy — so undefined / empty string
+    // values are an acceptable fallback shape, but the object itself must
+    // exist so the destructure does not throw.
+    expect(typeof cta).toBe('object');
+    expect(cta).not.toBeNull();
+  });
+
+  it('book always exposes a defined object (consumer guards with title + cover/description)', () => {
+    expect(book).toBeDefined();
+    expect(typeof book).toBe('object');
+    expect(book).not.toBeNull();
+    // BookShowcase.astro reads book?.title etc. and only renders when
+    // hasBook = !!(title && (coverImage || description)). Optional access
+    // means an empty-shape fallback is sufficient.
+  });
+
+  it('attributes always exposes a defined object', () => {
+    expect(attributes).toBeDefined();
+    expect(typeof attributes).toBe('object');
+    expect(attributes).not.toBeNull();
+  });
+
+  it('googleLinks always exposes a defined object (consumer uses optional chaining)', () => {
+    expect(googleLinks).toBeDefined();
+    expect(typeof googleLinks).toBe('object');
+    expect(googleLinks).not.toBeNull();
+    // Reviews.astro reads googleLinks?.allReviews, so undefined fields are fine.
   });
 });

--- a/src/data/_template-manifest.json
+++ b/src/data/_template-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "4.0.9",
   "description": "Template capability manifest \u2014 agent skills read this to validate their output stays within what the template can render.",
   "capabilities": {
     "heroStyles": [

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -13,10 +13,17 @@
  * in components. Their schemas are exported from ./schemas.ts for inline
  * validation.
  *
- * menu.json and team.json are also optional — non-restaurant fixtures don't
- * ship menu.json, non-team fixtures don't ship team.json. They're loaded via
- * import.meta.glob below and re-exported with safe empty defaults so that
- * static `import { menu, team }` consumers keep working.
+ * Pipeline-conditional data files are also loaded via import.meta.glob
+ * below and re-exported with safe empty defaults so that static
+ * `import { menu, team, cta, book, attributes, googleLinks } from
+ * '../lib/data'` consumers keep working when the file is absent. Per the
+ * Pipeline Data Contract these are emitted only under specific conditions:
+ *   - menu.json          — restaurants only
+ *   - team.json          — team-led businesses
+ *   - cta.json           — authors only
+ *   - book.json          — authors only
+ *   - attributes.json    — Places v2 with attributes
+ *   - google-links.json  — only written if links exist
  */
 import type { ZodSchema } from 'astro/zod';
 import {
@@ -65,22 +72,32 @@ import rawProjects from '../data/projects.json';
 import rawAlert from '../data/alert.json';
 import rawAnalytics from '../data/analytics.json';
 import rawTrustbar from '../data/trustbar.json';
-import rawCta from '../data/cta.json';
-import rawBook from '../data/book.json';
-import rawAttributes from '../data/attributes.json';
-import rawGoogleLinks from '../data/google-links.json';
 import rawSources from '../data/_sources.json';
 import rawTemplateManifest from '../data/_template-manifest.json';
 
-// Optional: menu.json (restaurants only) and team.json (team-led businesses only).
-// Loaded via import.meta.glob so absent files do not break the Astro build.
-// Mirrors the pattern used for tour.json / preview.json (BaseLayout.astro)
-// and process.json / differentiator.json (in their respective components).
+// Pipeline-conditional optional files — loaded via import.meta.glob so absent
+// files do not break the Astro build. Mirrors the pattern used for tour.json /
+// preview.json (BaseLayout.astro) and process.json / differentiator.json (in
+// their respective components). The fallback shape for each is the minimum the
+// downstream consumer needs to short-circuit cleanly when the file is absent
+// (CTASection / BookShowcase / Reviews all guard with truthy checks already).
 const menuFiles = import.meta.glob<{ default: unknown }>('../data/menu.json', { eager: true });
 const rawMenu: unknown = Object.values(menuFiles)[0]?.default ?? { categories: [] };
 
 const teamFiles = import.meta.glob<{ default: unknown }>('../data/team.json', { eager: true });
 const rawTeam: unknown = Object.values(teamFiles)[0]?.default ?? { items: [] };
+
+const ctaFiles = import.meta.glob<{ default: unknown }>('../data/cta.json', { eager: true });
+const rawCta: unknown = Object.values(ctaFiles)[0]?.default ?? { text: '', buttonText: '', buttonHref: '', enabled: false };
+
+const bookFiles = import.meta.glob<{ default: unknown }>('../data/book.json', { eager: true });
+const rawBook: unknown = Object.values(bookFiles)[0]?.default ?? { title: '' };
+
+const attributesFiles = import.meta.glob<{ default: unknown }>('../data/attributes.json', { eager: true });
+const rawAttributes: unknown = Object.values(attributesFiles)[0]?.default ?? {};
+
+const googleLinksFiles = import.meta.glob<{ default: unknown }>('../data/google-links.json', { eager: true });
+const rawGoogleLinks: unknown = Object.values(googleLinksFiles)[0]?.default ?? {};
 
 /** Validate with safeParse — warn on failure, never crash the build. */
 function validate<T>(schema: ZodSchema<T>, raw: unknown, name: string): T {

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -12,6 +12,11 @@
  * differentiator.json) are NOT imported here — they use import.meta.glob
  * in components. Their schemas are exported from ./schemas.ts for inline
  * validation.
+ *
+ * menu.json and team.json are also optional — non-restaurant fixtures don't
+ * ship menu.json, non-team fixtures don't ship team.json. They're loaded via
+ * import.meta.glob below and re-exported with safe empty defaults so that
+ * static `import { menu, team }` consumers keep working.
  */
 import type { ZodSchema } from 'astro/zod';
 import {
@@ -56,18 +61,26 @@ import rawTestimonials from '../data/testimonials.json';
 import rawFaq from '../data/faq.json';
 import rawAbout from '../data/about.json';
 import rawGallery from '../data/gallery.json';
-import rawMenu from '../data/menu.json';
 import rawProjects from '../data/projects.json';
 import rawAlert from '../data/alert.json';
 import rawAnalytics from '../data/analytics.json';
 import rawTrustbar from '../data/trustbar.json';
-import rawTeam from '../data/team.json';
 import rawCta from '../data/cta.json';
 import rawBook from '../data/book.json';
 import rawAttributes from '../data/attributes.json';
 import rawGoogleLinks from '../data/google-links.json';
 import rawSources from '../data/_sources.json';
 import rawTemplateManifest from '../data/_template-manifest.json';
+
+// Optional: menu.json (restaurants only) and team.json (team-led businesses only).
+// Loaded via import.meta.glob so absent files do not break the Astro build.
+// Mirrors the pattern used for tour.json / preview.json (BaseLayout.astro)
+// and process.json / differentiator.json (in their respective components).
+const menuFiles = import.meta.glob<{ default: unknown }>('../data/menu.json', { eager: true });
+const rawMenu: unknown = Object.values(menuFiles)[0]?.default ?? { categories: [] };
+
+const teamFiles = import.meta.glob<{ default: unknown }>('../data/team.json', { eager: true });
+const rawTeam: unknown = Object.values(teamFiles)[0]?.default ?? { items: [] };
 
 /** Validate with safeParse — warn on failure, never crash the build. */
 function validate<T>(schema: ZodSchema<T>, raw: unknown, name: string): T {

--- a/tests/visual/fixtures/_base/_template-manifest.json
+++ b/tests/visual/fixtures/_base/_template-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "4.0.9",
   "description": "Template capability manifest — agent skills read this to validate their output stays within what the template can render.",
   "capabilities": {
     "heroStyles": ["split", "overlay", "video", "minimal"],


### PR DESCRIPTION
Closes #90

## Summary

`src/lib/data.ts` had static `import rawMenu from '../data/menu.json'` and `import rawTeam from '../data/team.json'`. Non-restaurant fixtures (pwtint, martinezwelding) ship without `menu.json`; non-team fixtures (dcdrentals) ship without `team.json`. The platform fixture script flags them as "Optional file missing", but the static imports still fail the Astro build:

- `Could not resolve "../data/menu.json" from "src/lib/data.ts"` (pwtint, martinezwelding)
- `Could not resolve "../data/team.json" from "src/lib/data.ts"` (dcdrentals)

This was breaking the visual-diff CI workflow on every branch — a P2 issue masking real regressions.

### Changes

1. **`src/lib/data.ts`** — converted `menu.json` and `team.json` to the existing optional-glob pattern (`import.meta.glob('../data/menu.json', { eager: true })`) used elsewhere in the repo for `tour.json` / `preview.json` (BaseLayout) and `process.json` / `differentiator.json` (per-component). Re-exported with safe empty defaults (`{ categories: [] }`, `{ items: [] }`) so existing static `import { menu, team }` consumers (`MenuSection`, `Team`) keep working without code changes.

2. **`src/__tests__/data-optional.test.ts`** — new regression test that asserts the public contract: `menu.categories` and `team.items` are always arrays regardless of source-file presence.

3. **`_template-manifest.json` (both copies) bumped 0.1.0 → 4.0.9** to match `package.json`. PR fa5305f bumped `package.json` to 4.0.9 but missed the manifest, leaving the version-consistency test silently failing on every branch. Bump (instead of downgrade) so no client `.template-version` pin breaks.

## Test plan

- [x] `npm test` — all 19 test files / 157 tests pass (incl. new `data-optional.test.ts` and pre-existing `version-consistency`)
- [x] `npm run check` — no new errors introduced. The 8 pre-existing TS errors in PhotoGallery / ProjectGallery / FloatingCTA / OptimizedImg / QuoteForm exist on `main` and are out of scope here.
- [x] Local `astro build` succeeds **with** `menu.json` + `team.json` present (happy path)
- [x] Local `astro build` succeeds **without** `menu.json` and `team.json` (the bug-fix proof)
- [ ] CI: visual-diff workflow passes on all 3 fixtures (pwtint, martinezwelding, dcdrentals) — this is the success signal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated template manifest version to 4.0.9.

* **Tests**
  * Added tests ensuring exported data values are always defined and supply safe fallbacks when optional data is absent.

* **Refactor**
  * Improved data-loading so optional configuration files no longer break consumers and defaults are provided automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->