### PR TITLE
feat: foundations polish — type/spacing/radius scales + empty states + 404 + docs (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,18 @@ Client repos contain only data files (`src/data/*.json`, `src/content/`, `src/as
 
 ```
 src/
-├── components/        # 31 Astro components (sections + layout)
+├── components/        # Astro components (sections + layout)
 ├── content/           # Markdown collections (services/, products/)
-├── data/              # JSON data files (24 files)
+├── data/              # JSON data files
 ├── layouts/           # BaseLayout with theme CSS injection
-├── lib/               # Brand theming, image resolver, types
-├── pages/             # index.astro (data-driven section renderer)
+├── lib/               # Brand theming, image resolver, types, Zod schemas
+├── pages/             # index.astro + 404.astro
 ├── scripts/           # GSAP animation controller
 └── styles/            # tokens, base, layout, components, atmosphere, animations
-tests/visual/          # Playwright visual regression (10 fixtures x 7 viewports)
+tests/visual/          # Playwright visual regression (fixtures x viewports)
 ```
+
+---
 
 ## Section System
 
@@ -46,8 +48,8 @@ Sections are driven by `theme.json`. The page renderer loops over `sections` and
 {
   "sections": [
     { "id": "hero", "variant": "overlay" },
-    { "id": "trust", "variant": "badges" },
-    { "id": "services", "variant": "split" },
+    { "id": "trust", "variant": "stats" },
+    { "id": "services", "variant": "cards" },
     { "id": "products" },
     { "id": "cta" },
     { "id": "faq" },
@@ -57,74 +59,250 @@ Sections are driven by `theme.json`. The page renderer loops over `sections` and
 }
 ```
 
-### Available Sections
+Resolution order: explicit `component` override > variant override > default component for the section ID.
 
-| Section | Variants | Data Source |
-|---------|----------|-------------|
-| `hero` | split, overlay, video, minimal | `hero.json` |
-| `trust` | badges, stats | `trustbar.json` |
-| `services` | cards, icon-grid, compact, split | `content/services/*.md` |
-| `products` | -- | `content/products/*.md` |
-| `cta` | -- | `cta.json` |
-| `reviews` | scroll | `testimonials.json` |
-| `faq` | -- | `faq.json` |
-| `gallery` | masonry, scroll | `gallery.json` (+ optional Behold feed) |
-| `projects` | -- | `projects.json` |
-| `process` | -- | (hardcoded steps) |
-| `menu` | -- | `menu.json` |
-| `contact` | QuoteForm / OrderVisit (auto) | `contact.json` |
-| `about` | -- | `about.json`, `location.json` |
-| `hours` | -- | `hours.json` |
-| `beforeAfter` | -- | (content collection) |
-| `differentiator` | -- | (content collection) |
-| `marquee` | -- | `theme.json` marqueeItems |
-| `team` | -- | `team.json` |
+### Section → Variant Reference
 
-### Layout Tokens
+Every variant key the renderer recognises. Variants not listed here render the default component; unknown values fall back silently.
 
-`theme.json` also controls the visual design system:
+| Section | Default component | Variant keys | Notes |
+|---------|-------------------|--------------|-------|
+| `hero` | `Hero` | `split`, `overlay`, `video`, `minimal` | Also accepts `"1"..."3"` from pipeline |
+| `trust` | `TrustBar` | `stats` → `TrustStats` | Stat-number card variant |
+| `services` | `ServiceCards` | `cards`, `icon-grid`, `compact`, `split`, `options` → `ServiceOptions` | |
+| `products` | `Products` | — | Content collection (`src/content/products/`) |
+| `projects` | `ProjectGallery` | — | |
+| `process` | `ProcessSteps` | — | Falls back to hardcoded steps when `process.json` is absent |
+| `gallery` | `PhotoGallery` | `masonry` (default), `scroll`, `category-grid` | |
+| `menu` | `MenuSection` | — | |
+| `reviews` | `Reviews` | — | Aggregate banner only (Google ToS compliant) |
+| `faq` | `FAQ` | — | Accordion |
+| `contact` | `QuoteForm` | `order-visit` → `OrderVisit` | `order-visit` for restaurants |
+| `about` | `AboutMap` | `author-bio` → `AuthorBio` | Author variant for book sites |
+| `hours` | `HoursDisplay` | — | |
+| `beforeAfter` | `BeforeAfter` | — | Content collection |
+| `differentiator` | `Differentiator` | — | `differentiator.json` (optional) |
+| `marquee` | `Marquee` | — | Strings from `theme.marqueeItems` |
+| `team` | `Team` | — | |
+| `cta` | `CTASection` | — | |
+| `book` | `BookShowcase` | — | Author sites |
+| `facility` | `Facility` | — | |
 
-```json
+**Fallback section order** (when `theme.sections` is empty): `hero, trust, services, projects, process, reviews, faq, contact, about`.
+
+### Branded Empty States
+
+When a section is listed in `theme.sections` but the backing data is thin or missing, the template renders a branded "coming soon" placeholder instead of a broken-looking half-section. If the operator omits the section from `theme.sections` entirely, nothing renders.
+
+Rules:
+
+| Section | Placeholder triggers when |
+|---------|---------------------------|
+| `reviews` | `testimonials.reviewCount === 0` AND `testimonials.averageRating === 0` |
+| `gallery` | `gallery.images.length === 0` AND no `gallery.beholdFeedId` |
+| `menu` | No category has items (or `menu.categories` empty) |
+| `faq` | `faq.items.length === 0` |
+| `testimonials` | `testimonials.items.length === 0` AND no review aggregate |
+
+Placeholders use `--text-lead`, `--space-*`, `--radius-md`, and the brand accent color — they stay visually consistent with the rest of the site.
+
+### Adding a Section
+
+1. Create `src/components/NewSection.astro`
+2. Import it in `src/pages/index.astro` and add to `componentMap`
+3. Add the section ID to `DEFAULT_COMPONENTS` in `src/lib/section-registry.ts`
+4. Register the section ID in `src/data/_template-manifest.json` → `capabilities.sectionIds`
+5. List the section in `theme.sections` in the desired position
+
+---
+
+## Design Tokens
+
+Token layer is split across injected brand CSS (`src/lib/brand.ts`) and the structural defaults in `src/styles/tokens.css`. Components should reference tokens — never hardcode colors, sizes, or radii.
+
+### Typography Tokens
+
+Fluid type scale on a 1.25 ratio. `--text-base` is overridable via `brand.typography.baseSize`; every other step stays locked to the ratio so the scale stays consistent.
+
+| Token | Default | Purpose |
+|-------|---------|---------|
+| `--text-display` | `clamp(2.75rem, 2.2rem + 2.75vw, 4rem)` | Largest headline, 404 eyebrow, ultra-hero lines |
+| `--text-h1` | `clamp(2.25rem, 1.9rem + 1.75vw, 3rem)` | Section H1 / hero headline |
+| `--text-h2` | `clamp(1.75rem, 1.5rem + 1.25vw, 2.25rem)` | Section H2 |
+| `--text-h3` | `clamp(1.375rem, 1.25rem + 0.63vw, 1.625rem)` | Section H3, card titles |
+| `--text-lead` | `clamp(1.125rem, 1.05rem + 0.38vw, 1.25rem)` | Subhead / intro paragraph |
+| `--text-base` | `clamp(1rem, 0.94rem + 0.3vw, 1.125rem)` | Body copy — overridable via brand.json |
+| `--text-body` | alias of `--text-base` | Body copy (semantic alias) |
+| `--text-small` | `clamp(0.875rem, 0.83rem + 0.22vw, 0.9375rem)` | Small print, captions on dense UI |
+| `--text-caption` | `clamp(0.75rem, 0.72rem + 0.15vw, 0.8125rem)` | Eyebrow labels, metadata |
+| `--leading-tight` | `1.1` | Display-size headings |
+| `--leading-snug` | `1.2` | H1–H3 |
+| `--leading-normal` | `1.5` | Body |
+| `--leading-loose` | `1.7` | Long-form reading |
+
+Legacy aliases (`--display-size`, `--title-size`, `--body-size`, etc.) remain in `tokens.css` and map onto the named scale — old components keep working.
+
+### Spacing Tokens
+
+Geometric scale multiplied by `--density-multiplier` (default `1`). Change `brand.spacing.density` to `"compact"` (0.85) or `"airy"` (1.15) to scale the whole layout in one switch.
+
+| Token | Default (×1) | Purpose |
+|-------|--------------|---------|
+| `--space-3xs` | `0.25rem` | Hairline gaps (icon + label) |
+| `--space-2xs` | `0.5rem` | Tight clusters |
+| `--space-xs` | `0.75rem` | Button padding, small form gaps |
+| `--space-sm` | `1rem` | Default gap |
+| `--space-md` | `1.5rem` | Card inner padding |
+| `--space-lg` | `2.5rem` | Section inner spacing |
+| `--space-xl` | `4rem` | Placeholder / hero inner padding |
+| `--space-2xl` | `6rem` | Between major content blocks |
+| `--space-3xl` | `10rem` | Rarely needed, top-of-page accents |
+
+Legacy aliases (`--gap`, `--gap-md`, `--gap-xl`, etc.) map onto the named scale and respond to the density multiplier automatically.
+
+### Radius Tokens
+
+Four-step named scale. `brand.radius.style` switches the whole scale atomically.
+
+| Token | `sharp` | `rounded` (default) | `soft` |
+|-------|---------|---------------------|--------|
+| `--radius-sm` | `0` | `0.25rem` | `0.5rem` |
+| `--radius-md` | `2px` | `0.5rem` | `1rem` |
+| `--radius-lg` | `4px` | `1rem` | `1.5rem` |
+| `--radius-pill` | `9999px` | `9999px` | `9999px` |
+
+Legacy tokens (`--radius`, `--radius-xs`, `--radius-xl`, `--radius-full`) remain as aliases so older components do not need edits.
+
+### Other Structural Tokens
+
+Full list lives in `src/styles/tokens.css`. Common ones components reference:
+
+- Surfaces: `--bg`, `--surface`, `--surfaceAlt`, `--text`, `--textMuted`, `--border`, `--borderSubtle`
+- Accent: `--accent`, `--accentDim`, `--accentGlow`
+- Motion: `--ease-out-expo`, `--ease-spring`, `--duration-fast`, `--duration-normal`
+- Shadows: `--shadow-card`, `--shadow-glow`, `--shadow-glass`
+- Layout: `--section-pad`, `--section-gap`, `--content-width`, `--content-narrow`, `--content-reading`
+- Interaction: `--hover-scale`, `--hover-shadow`, `--glass-opacity`
+
+### Layout Tokens (`theme.layout`)
+
+Data-driven design knobs set per site. Applied as `data-*` attributes on `<body>` or emitted as CSS custom properties by `generateLayoutCSS()`.
+
+| Token | Values | Effect |
+|-------|--------|--------|
+| `heroStyle` | `split`, `overlay`, `video`, `minimal` | Hero component variant |
+| `headerStyle` | `solid`, `glass`, `transparent` | Header background treatment |
+| `headerPosition` | `sticky`, `static`, `hidden-on-scroll` | Header scroll behavior |
+| `cardStyle` | `bordered`, `shadow`, `flat`, `elevated`, `luxury` | Card visual treatment |
+| `cardRadius` | `sharp`, `soft`, `round` | `--card-radius` |
+| `buttonStyle` | `rounded`, `pill`, `square` | `--btn-radius` |
+| `buttonVariant` | `solid`, `ghost`, `tactile` | Button fill style |
+| `sectionPattern` | `none`, `alternating`, `gradient`, `wave`, `angle` | Background rhythm |
+| `sectionGap` | `tight`, `normal`, `spacious` | `--section-gap` |
+| `atmosphereLevel` | `none`, `minimal`, `rich`, `cinematic` | Noise overlay + ambient effects |
+| `motionIntensity` | `none`, `subtle`, `standard`, `dramatic` | GSAP animation strength |
+| `dividerStyle` | `line`, `glow`, `fade`, `none` | Section dividers |
+| `typographyScale` | `compact`, `standard`, `editorial`, `display` | Overrides `--font-size-base/h1/h2` |
+| `imageStyle` | `rounded`, `sharp`, `masked` | `--img-radius` |
+| `shadowStyle` | `subtle`, `standard`, `dramatic` | `--shadow-card` |
+| `hoverIntensity` | `none`, `subtle`, `standard` | `--hover-scale`, `--hover-shadow` |
+| `overlayDarkness` | `light`, `medium`, `heavy` | `--overlay-darkness` |
+| `glassOpacity` | `subtle`, `standard`, `heavy` | `--glass-opacity` |
+| `borderWeight` | `none`, `subtle`, `standard` | `--border-weight` |
+
+All valid values are machine-readable in `src/data/_template-manifest.json`.
+
+### Brand Knobs (`brand.json`)
+
+Three optional knobs introduced by the foundations-polish wave (issue #79). All three default to the historical look when omitted — existing client repos keep rendering identically.
+
+```jsonc
 {
-  "layout": {
-    "heroStyle": "overlay",
-    "atmosphereLevel": "rich",
-    "motionIntensity": "standard",
-    "headerStyle": "glass",
-    "cardStyle": "elevated",
-    "cardRadius": "soft",
-    "buttonStyle": "rounded",
-    "buttonVariant": "tactile",
-    "dividerStyle": "glow",
-    "sectionPattern": "gradient"
+  // ...existing palette + fonts...
+
+  "typography": {
+    "baseSize": "1.0625rem"           // Optional. Overrides --text-base.
+                                      // The 1.25 ratio stays locked; only the
+                                      // base shifts, so the rest of the scale
+                                      // stays consistent.
+  },
+
+  "spacing": {
+    "density": "comfortable"          // "compact" | "comfortable" | "airy".
+                                      // Drives --density-multiplier:
+                                      //   compact     = 0.85
+                                      //   comfortable = 1.0 (default)
+                                      //   airy        = 1.15
+                                      // Whole spacing scale scales atomically.
+  },
+
+  "radius": {
+    "style": "rounded"                // "sharp" | "rounded" | "soft".
+                                      // Switches the entire --radius-* scale.
+                                      //   sharp   -> 0 / 2px / 4px
+                                      //   rounded -> 0.25rem / 0.5rem / 1rem (default)
+                                      //   soft    -> 0.5rem / 1rem / 1.5rem
   }
 }
 ```
 
-All valid values are documented in `src/data/_template-manifest.json`.
+---
 
 ## Data Files
 
-| File | Contents |
-|------|----------|
-| `brand.json` | Color palette (light + dark), font families |
-| `client.json` | Business name, industry, slug |
-| `contact.json` | Phone, email, social links |
-| `location.json` | Address, map link, service area |
-| `hero.json` | Headline, tagline, hero image, CTA |
-| `theme.json` | Section order, variants, layout tokens, marquee |
-| `cta.json` | CTA band text, button, enabled flag |
-| `hours.json` | Business hours by day |
-| `faq.json` | Question/answer pairs |
-| `gallery.json` | Image list + optional Behold feed ID |
-| `testimonials.json` | Customer reviews |
-| `trustbar.json` | Trust bar items or stats |
-| `seo.json` | Page title, meta description, OG tags |
-| `schema.json` | JSON-LD structured data |
-| `alert.json` | Banner text, dates, enabled flag |
-| `menu.json` | Restaurant menu categories + items |
-| `team.json` | Team members (barbers, stylists, etc.) |
-| `projects.json` | Portfolio/project gallery |
+All data lives in `src/data/`. Files are plain JSON imported and Zod-validated at build time by `src/lib/data.ts`. Validation failures log a warning but do not block the build — client data varies widely.
+
+| File | Required | Shape |
+|------|----------|-------|
+| `client.json` | Yes | `{ name, slug?, foundingYear?, license?, insured?, serviceArea?, industry?, delivery?, orderUrl?, socials?, domain?, logoUrl? }` |
+| `brand.json` | Yes | `{ palette: {bg, surface, surfaceAlt, text, textMuted, accent, accentDim?, accentGlow?, border?, borderSubtle?}, nameFont, headingFont, bodyFont, monoFont?, nameTreatment?, typography?, spacing?, radius? }` |
+| `theme.json` | Yes | `{ sections[], sectionOrder[]?, accentStyle?, faviconShape?, industry?, layout?, marqueeItems?, nav?, cta?, heroCta?, actionBar? }` |
+| `contact.json` | Yes | `{ email, phoneForTel, phone? }` |
+| `location.json` | Yes | `{ address, city, state, zip, country, mapLink, lat?, lng? }` |
+| `hero.json` | Yes | `{ heroImage, heroTagline, heroSubtitle, fallbackImage?, heroVideo?, videoUrl?, videoPoster?, cta? }` |
+| `seo.json` | Yes | `{ pageTitle, metaDescription, ogTitle, ogDescription, ogImage, canonicalUrl }` |
+| `schema.json` | Yes | Free-form JSON-LD (injected as `<script type="application/ld+json">`) |
+| `hours.json` | Yes | `{ days: [{ day, open, close }], secondaryHours? }` |
+| `testimonials.json` | Yes | `{ reviewCount?, averageRating?, allReviewsUrl?, items?[] }` (aggregate-only for Google ToS) |
+| `trustbar.json` | Yes | `{ items: [{ number, label }] }` |
+| `faq.json` | Yes | `{ items: [{ question, answer, source? }] }` |
+| `about.json` | Yes | `{ heading, text, image? }` |
+| `cta.json` | Conditional (authors) | `{ text, buttonText, buttonHref, enabled? }` |
+| `alert.json` | Yes | `{ enabled, text, startDate?, endDate? }` |
+| `gallery.json` | Yes | `{ beholdFeedId?, images: [{ url, alt, fallbackUrl? }] }` |
+| `menu.json` | Conditional (restaurants) | `{ categories: [{ name, items: [{ name, description?, price?, featured?, photo? }] }] }` |
+| `projects.json` | Yes | `{ projects: [{ title, description, before, after, during?, service }] }` |
+| `team.json` | Conditional (team-led) | `{ items: [{ name, brandName?, title?, bio?, photo?, bookingUrl?, bookingLabel?, hours?, specialties?, order? }] }` |
+| `analytics.json` | Yes | `{ umamiWebsiteId, umamiScriptUrl }` — empty string = disabled |
+| `book.json` | Conditional (authors) | `{ title, subtitle?, description?, blurb?, coverImage?, backCoverImage?, purchaseUrl?, formats?, publishDate?, publisher?, isbn? }` |
+| `attributes.json` | Conditional | Free-form Places API attributes |
+| `google-links.json` | Conditional | `{ directions?, writeReview?, allReviews?, photos?, place? }` |
+| `_sources.json` | Internal | Source attribution for data fields |
+| `_template-manifest.json` | Internal | Valid layout tokens, section IDs, component overrides |
+| `process.json` | Optional | `{ heading?, eyebrow?, steps: [{ number?, title, description, icon? }] }` |
+| `preview.json` | Optional | `{ businessName, slug }` — present = preview mode (disclaimer + noindex) |
+| `tour.json` | Optional | `{ steps: [{ target, title, body }], businessName? }` — driver.js guided tour |
+| `differentiator.json` | Optional | `{ heading?, eyebrow?, us?, them?, items? }` |
+
+**Content collections** (markdown with frontmatter): `src/content/services/*.md` and `src/content/products/*.md`.
+
+### Conditional Files
+
+Per the platform Pipeline Data Contract, these are emitted only under specific conditions:
+
+- `menu.json` — restaurants only
+- `team.json` — team-led businesses only
+- `cta.json`, `book.json` — authors only
+- `attributes.json` — Places v2 responses with attribute data
+- `google-links.json` — only written when links exist
+
+Consumers defensively default to empty shapes via `import.meta.glob` in `src/lib/data.ts`, so absent files never break the build.
+
+### Authoritative Schemas
+
+Every data shape is encoded as a Zod schema in `src/lib/schemas.ts` and surfaced as a TypeScript type via `z.infer<>` in `src/lib/types.ts`. If a field is missing from this README but appears in the schemas, the schemas win. Update both whenever the contract changes.
+
+---
 
 ## Development
 
@@ -137,12 +315,14 @@ npm run test       # Vitest unit tests
 
 ### Visual Regression Tests
 
-10 fixture configurations x 7 viewport sizes. Fixtures live in `tests/visual/fixtures/` and cover service businesses, restaurants, edge cases, light/dark palettes, and all layout variants.
+Fixtures live in `tests/visual/fixtures/`. Run them with Playwright:
 
 ```bash
 cd tests/visual
 npx playwright test
 ```
+
+---
 
 ## Versioning
 

--- a/docs/superpowers/plans/2026-04-22-template-foundations-polish.md
+++ b/docs/superpowers/plans/2026-04-22-template-foundations-polish.md
@@ -1,0 +1,160 @@
+# Template Foundations Polish — Implementation Plan
+
+**Issue:** [ziamade/template-dukecitymodern#79](https://github.com/ziamade/template-dukecitymodern/issues/79)
+**Spec:** `docs/superpowers/specs/2026-04-15-template-foundations-polish-design.md` in the platform repo (landed on master via platform PR #600)
+**Sibling (pipeline-side):** [ziamade-platform#431](https://github.com/ziamade/ziamade-platform/issues/431) — happens in parallel; neither blocks the other because pipeline changes are additive and default to current behavior.
+
+## Scope (this issue, per spec)
+
+Three bundles:
+1. **Modular foundation-token layer** — named tokens for type, spacing, radius. (Shadow, motion, z-index are spec'd but are a stretch goal; prioritize the three that ship the biggest UX lift and that the brand knobs route through.)
+2. **Branded empty states + custom 404** — reviews / gallery / testimonials / menu / FAQ degrade to branded placeholders; 404 uses brand tokens.
+3. **Expanded README + in-repo docs** — every variant key, token, and data file documented.
+
+## Out of scope
+
+- View Transitions — dropped per spec (single-page sites, zero payoff)
+- Tailwind migration — dropped per spec
+- Section variants (issue #80), Zod content collections (issue #81)
+- Component-level visual redesign (later T1-T6 waves)
+- Pipeline/data-contract shape changes (all three new `brand.json` fields are optional and ship in #431)
+
+## PR split
+
+Spec suggests 3 PRs. Bundle all three into a **single PR** for this issue. Reasons:
+- One branch = one review cycle = faster merge
+- Ordering dependency is strict (tokens → empty states → docs), so a single PR keeps history linear
+- All three share the brand-injection layer so review context is coherent
+
+If the subagent finds the diff growing past ~800 lines, split into two at the tokens/empty-states boundary. README expansion can stay in either PR.
+
+## File-level plan
+
+### Step 1 — Read the current brand-injection layer
+
+- Locate `src/lib/brand.ts` (or equivalent) — this is where `brand.json` is read and turned into CSS variables.
+- Locate `tokens.css` (or equivalent root CSS file where `:root { --... }` lives). If no such file exists, identify where theme tokens currently live (inline styles, per-component, global.css).
+- Grep existing components for hardcoded `font-size`, `padding`, `border-radius` values. The named-token conversion in step 2 will replace these.
+
+### Step 2 — Implement the type scale (1.25 ratio, fluid)
+
+From the spec §Item 1a:
+
+```css
+:root {
+  --text-base: clamp(1rem, 0.94rem + 0.3vw, 1.125rem);
+  --text-caption:  clamp(0.75rem,  0.72rem + 0.15vw, 0.8125rem);
+  --text-small:    clamp(0.875rem, 0.83rem + 0.22vw, 0.9375rem);
+  --text-body:     var(--text-base);
+  --text-lead:     clamp(1.125rem, 1.05rem + 0.38vw, 1.25rem);
+  --text-h3:       clamp(1.375rem, 1.25rem + 0.63vw, 1.625rem);
+  --text-h2:       clamp(1.75rem,  1.5rem  + 1.25vw, 2.25rem);
+  --text-h1:       clamp(2.25rem,  1.9rem  + 1.75vw, 3rem);
+  --text-display:  clamp(2.75rem,  2.2rem  + 2.75vw, 4rem);
+  --leading-tight: 1.1;
+  --leading-snug:  1.2;
+  --leading-normal: 1.5;
+  --leading-loose: 1.7;
+}
+```
+
+- Add these tokens to `tokens.css` (or the equivalent root CSS file).
+- Add brand-knob: `brand.json.typography.baseSize` (optional rem string). In `src/lib/brand.ts`, read it; if present, emit `--text-base: <value>;` inline via the CSS custom-property injection the template already does for palette/fonts. Do not allow per-step overrides — the ratio stays consistent.
+- Walk every component under `src/components/` and swap hardcoded `font-size: ...` values to the matching named token (`var(--text-h1)`, etc.). If a component uses a size that doesn't fit the scale cleanly, pick the nearest named token — don't invent new ones.
+- Test: build the site against an existing fixture (`pwtint` or similar in `packages/test-data` or wherever the template consumes fixture data), visually confirm typography still looks reasonable in light + dark modes.
+
+### Step 3 — Implement the spacing scale
+
+From spec §Item 1b:
+
+```css
+:root {
+  --space-3xs: 0.25rem;
+  --space-2xs: 0.5rem;
+  --space-xs:  0.75rem;
+  --space-sm:  1rem;
+  --space-md:  1.5rem;
+  --space-lg:  2.5rem;
+  --space-xl:  4rem;
+  --space-2xl: 6rem;
+  --space-3xl: 10rem;
+}
+```
+
+- Add to `tokens.css`.
+- Brand-knob: `brand.json.spacing.density` ∈ `"compact" | "comfortable" | "airy"`. In `src/lib/brand.ts`, read and apply a multiplier (0.85, 1.0, 1.15) to the whole scale. Default `comfortable`. Implementation pattern: emit each `--space-*` as a multiplied value (since CSS can't do `calc(var(--density) * 1rem)` at runtime without also injecting the multiplier, simplest is to emit the computed values directly in the theme CSS or wrap each in a `calc()` with an injected `--density-multiplier`).
+- Swap hardcoded `padding` / `margin` / `gap` values across components to named tokens. Same rule: pick the nearest named token, don't invent.
+
+### Step 4 — Implement the radius scale
+
+- Define named radius tokens (spec does not enumerate values; derive a sensible 4-step scale). Suggested:
+  - `--radius-sm: 0.25rem;` `--radius-md: 0.5rem;` `--radius-lg: 1rem;` `--radius-pill: 9999px;`
+- Brand-knob: `brand.json.radius.style` ∈ `"sharp" | "rounded" | "soft"`. Multiplier or replacement scheme:
+  - `sharp`: 0 / 2px / 4px / 9999px
+  - `rounded` (default): values above
+  - `soft`: 0.5rem / 1rem / 1.5rem / 9999px
+- Apply to `tokens.css` + `src/lib/brand.ts`. Walk components, swap hardcoded `border-radius` values.
+
+### Step 5 — Conditional empty states
+
+For each of **reviews**, **gallery**, **testimonials**, **menu**, **FAQ**:
+
+- Find the component that renders the section (typically `src/components/sections/<Name>.astro` or `src/pages/index.astro` inclusions).
+- Current behavior: section either renders or is silently omitted when data is thin (e.g. gallery hides when `photos.length < 3`).
+- New behavior: section renders a **branded placeholder** — a styled element using brand tokens (palette, type scale, radius) that says "Reviews coming soon" / "Gallery photos coming soon" / etc. One-line copy, centered, uses `--space-*` padding, `--radius-*` for any enclosing card, `--text-lead` for the copy, brand accent color for any icon or accent.
+- If the business has *genuinely no data* for a section (e.g., a trades business has no menu — not even a placeholder), continue to hide the section entirely. The placeholder is for "data thin but present" cases like 1 review or 2 gallery photos.
+- Rule from the spec: never a broken-looking half-section. Pick hide vs placeholder per section semantically.
+
+### Step 6 — Custom 404 page
+
+- `src/pages/404.astro` — create if missing, style if present with hardcoded values.
+- Use brand tokens for palette, type scale, radius.
+- Single message + link back to home. No menu, no footer clutter. One line of copy.
+- Playwright check: navigate to a nonexistent path, confirm 404 renders with brand colors.
+
+### Step 7 — Expand README + in-repo docs
+
+- `README.md` — add sections:
+  - **Variants** — list every `theme.json` variant key and what it controls. Example: `hero.variant: "1" | "2" | "3"` → describe each.
+  - **Tokens** — list every `--text-*`, `--space-*`, `--radius-*` token with its purpose.
+  - **Data files** — for each `src/data/*.json` the template consumes, list the shape and required fields. Cross-link to the platform-side `packages/pipeline/CLAUDE.md § Pipeline Data Contract` if appropriate.
+  - **Brand knobs** — three new ones: `typography.baseSize`, `spacing.density`, `radius.style`. Defaults + semantics.
+- Write it for a new contributor and a future-you returning six weeks from now. Tight prose, code-block examples, no fluff.
+
+### Step 8 — Verify existing client repos still build
+
+- The template is consumed at build-time by client site repos (per platform CLAUDE.md § Build-time template injection).
+- Run the template build against an existing fixture that ships without the new brand knobs. Confirm the site renders identically to pre-change (tokens must default to the current look).
+- If there's a snapshot / visual-diff CI on this repo, run it locally before pushing.
+
+## Order
+
+1. Read brand-injection layer (step 1)
+2. Type scale (step 2) — biggest lever, do first
+3. Spacing scale (step 3)
+4. Radius scale (step 4)
+5. Empty states (step 5)
+6. 404 page (step 6)
+7. README expansion (step 7)
+8. Verify no-knobs backward-compat (step 8)
+
+## Tests
+
+- Tokens: visual Playwright pass (light + dark mode, desktop + mobile) against at least one fixture. Capture screenshots; commit to `tests/snapshots/` only if this repo does snapshot testing. If not, eyeball + describe in PR body.
+- Empty states: feed in a fixture where each section is thin (1 review, 2 photos, 0 testimonials). Confirm placeholder renders, not a broken layout.
+- 404: Playwright navigate to `/nonsense`, assert the 404 page.
+- Backward compat: build the same fixture that's been rendering today with no knobs. Diff rendered output — should match.
+
+## Risks / edge cases
+
+- **Brand-injection layer unknown until read.** If `src/lib/brand.ts` emits CSS via some mechanism other than inline style (e.g. pre-compiled tokens file), token injection strategy may differ from what step 2-4 assumes. Adapt without re-spec'ing — the knob shape is fixed, the injection mechanism is template-internal.
+- **Hardcoded values are many.** Expect 100+ sites across components. Don't try to refactor on the same pass — mechanical grep + replace, trust tests + Playwright to catch misses.
+- **Fluid type + density multiplier interaction.** If the density multiplier applies to `--text-base` via `--density-multiplier`, the clamp() math breaks. Keep typography scale unaffected by density — density touches only spacing tokens.
+- **Empty-state "never a broken-looking half-section" is judgment-heavy.** When in doubt, prefer the placeholder over hiding. Operator can always edit a section out if they disagree.
+
+## PR
+
+- Title: `feat(template): foundations polish — type/spacing/radius scales + empty states + 404 + docs (#79)`
+- Branch: `feat/79-template-foundations-polish`
+- Target: `main` (template uses `main`, not `master`)
+- Test plan bullets: Playwright visual pass, 404 render, empty-state render with thin fixture, backward-compat check on an unchanged fixture.

--- a/src/components/SectionEmptyState.astro
+++ b/src/components/SectionEmptyState.astro
@@ -1,0 +1,75 @@
+---
+/**
+ * SectionEmptyState.astro — branded "coming soon" placeholder for thin-data
+ * sections (reviews, gallery, testimonials, menu, FAQ).
+ *
+ * Per the foundations-polish spec (issue #79): when a section is listed in
+ * theme.json but the backing data is thin or missing, render a branded
+ * placeholder instead of leaving a broken-looking half-section. When the
+ * business genuinely has no data for a category (e.g., a trades business
+ * with no menu), omit the section from theme.json entirely — this component
+ * is never rendered in that case.
+ *
+ * Styling: uses --text-lead, --space-*, --radius-md, and the brand accent
+ * color. No hardcoded font-size / padding / border-radius.
+ */
+interface Props {
+  sectionId: string;
+  heading: string;
+  message: string;
+  /** Optional: override the default h2 heading (e.g. "Reviews"). */
+  eyebrow?: string;
+}
+const { sectionId, heading, message, eyebrow } = Astro.props;
+---
+<section class={`empty-state-section section empty-state--${sectionId}`} id={sectionId} aria-label={heading}>
+  <div class="container">
+    <div class="empty-state-card reveal-up">
+      {eyebrow && <span class="empty-state-eyebrow">{eyebrow}</span>}
+      <h2 class="empty-state-heading">{heading}</h2>
+      <p class="empty-state-message">{message}</p>
+    </div>
+  </div>
+</section>
+
+<style>
+  .empty-state-section {
+    padding: var(--section-pad, clamp(5rem, 3rem + 5vw, 10rem)) 0;
+  }
+
+  .empty-state-card {
+    max-width: 640px;
+    margin: 0 auto;
+    padding: var(--space-xl, 4rem) var(--space-md, 1.5rem);
+    text-align: center;
+    background: color-mix(in srgb, var(--surface) 100%, transparent);
+    border: 1px solid var(--borderSubtle, var(--border));
+    border-radius: var(--radius-md, 0.5rem);
+  }
+
+  .empty-state-eyebrow {
+    display: inline-block;
+    font-family: var(--font-body);
+    font-size: var(--text-caption, 0.75rem);
+    font-weight: 600;
+    letter-spacing: var(--tracking-caps, 0.15em);
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: var(--space-xs, 0.75rem);
+  }
+
+  .empty-state-heading {
+    font-family: var(--font-heading);
+    font-size: var(--text-h2, 2rem);
+    line-height: var(--leading-snug, 1.2);
+    color: var(--text);
+    margin: 0 0 var(--space-xs, 0.75rem) 0;
+  }
+
+  .empty-state-message {
+    font-size: var(--text-lead, 1.125rem);
+    line-height: var(--leading-normal, 1.5);
+    color: var(--textMuted, var(--text));
+    margin: 0;
+  }
+</style>

--- a/src/lib/__tests__/empty-states.test.ts
+++ b/src/lib/__tests__/empty-states.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Branded empty-state logic lives in src/pages/index.astro as a
+ * shouldShowEmptyState() helper. These tests mirror that helper so the
+ * rules stay machine-verified without needing to render an Astro page.
+ *
+ * If the real index.astro logic changes shape, rebuild this oracle to
+ * match — the test is the regression anchor, not the production code.
+ */
+
+type TestimonialsLike = {
+  reviewCount?: number | null;
+  averageRating?: number | null;
+  items?: Array<unknown>;
+};
+type GalleryLike = { images?: Array<unknown>; beholdFeedId?: string };
+type MenuLike = { categories?: Array<{ items?: Array<unknown> }> };
+type FaqLike = { items?: Array<unknown> };
+
+function shouldShowEmptyState(
+  id: string,
+  data: {
+    testimonials?: TestimonialsLike;
+    gallery?: GalleryLike;
+    menu?: MenuLike;
+    faq?: FaqLike;
+  },
+): boolean {
+  const hasReviews = (data.testimonials?.reviewCount ?? 0) > 0 ||
+    (data.testimonials?.averageRating ?? 0) > 0;
+  const hasGalleryData = (data.gallery?.images?.length ?? 0) > 0 ||
+    Boolean(data.gallery?.beholdFeedId);
+  const hasMenuData = (data.menu?.categories?.length ?? 0) > 0 &&
+    (data.menu?.categories ?? []).some(c => (c.items?.length ?? 0) > 0);
+  const hasFaqData = (data.faq?.items?.length ?? 0) > 0;
+  const hasTestimonialItems = (data.testimonials?.items?.length ?? 0) > 0;
+
+  switch (id) {
+    case 'reviews':      return !hasReviews;
+    case 'gallery':      return !hasGalleryData;
+    case 'menu':         return !hasMenuData;
+    case 'faq':          return !hasFaqData;
+    case 'testimonials': return !hasTestimonialItems && !hasReviews;
+    default:             return false;
+  }
+}
+
+describe('empty-state rendering rules', () => {
+  describe('reviews', () => {
+    it('shows placeholder when reviewCount and averageRating are both 0', () => {
+      expect(shouldShowEmptyState('reviews', {
+        testimonials: { reviewCount: 0, averageRating: 0 },
+      })).toBe(true);
+    });
+
+    it('shows placeholder when testimonials is missing entirely', () => {
+      expect(shouldShowEmptyState('reviews', {})).toBe(true);
+    });
+
+    it('omits placeholder when reviewCount > 0', () => {
+      expect(shouldShowEmptyState('reviews', {
+        testimonials: { reviewCount: 42, averageRating: 0 },
+      })).toBe(false);
+    });
+
+    it('omits placeholder when averageRating > 0 even with reviewCount 0', () => {
+      expect(shouldShowEmptyState('reviews', {
+        testimonials: { reviewCount: 0, averageRating: 4.8 },
+      })).toBe(false);
+    });
+  });
+
+  describe('gallery', () => {
+    it('shows placeholder when images array is empty and no behold feed', () => {
+      expect(shouldShowEmptyState('gallery', { gallery: { images: [] } })).toBe(true);
+    });
+
+    it('omits placeholder when images are present', () => {
+      expect(shouldShowEmptyState('gallery', {
+        gallery: { images: [{ url: 'a' }] },
+      })).toBe(false);
+    });
+
+    it('omits placeholder when behold feed is configured but no static images', () => {
+      expect(shouldShowEmptyState('gallery', {
+        gallery: { images: [], beholdFeedId: 'abc' },
+      })).toBe(false);
+    });
+  });
+
+  describe('menu', () => {
+    it('shows placeholder when categories array is empty', () => {
+      expect(shouldShowEmptyState('menu', { menu: { categories: [] } })).toBe(true);
+    });
+
+    it('shows placeholder when categories exist but every category is itemless', () => {
+      expect(shouldShowEmptyState('menu', {
+        menu: { categories: [{ items: [] }, { items: [] }] },
+      })).toBe(true);
+    });
+
+    it('omits placeholder when at least one category has items', () => {
+      expect(shouldShowEmptyState('menu', {
+        menu: { categories: [{ items: [] }, { items: [{ name: 'Taco' }] }] },
+      })).toBe(false);
+    });
+  });
+
+  describe('faq', () => {
+    it('shows placeholder when items array is empty', () => {
+      expect(shouldShowEmptyState('faq', { faq: { items: [] } })).toBe(true);
+    });
+
+    it('omits placeholder when items are present', () => {
+      expect(shouldShowEmptyState('faq', {
+        faq: { items: [{ q: 'a', a: 'b' }] },
+      })).toBe(false);
+    });
+  });
+
+  describe('testimonials', () => {
+    it('shows placeholder when items is empty and no review aggregate', () => {
+      expect(shouldShowEmptyState('testimonials', {
+        testimonials: { items: [], reviewCount: 0 },
+      })).toBe(true);
+    });
+
+    it('omits placeholder when item array has entries', () => {
+      expect(shouldShowEmptyState('testimonials', {
+        testimonials: { items: [{ text: 'great' }] },
+      })).toBe(false);
+    });
+
+    it('omits placeholder when aggregate reviews exist (even without items)', () => {
+      expect(shouldShowEmptyState('testimonials', {
+        testimonials: { items: [], reviewCount: 12, averageRating: 4.5 },
+      })).toBe(false);
+    });
+  });
+
+  describe('unknown section ids', () => {
+    it('never shows placeholder for sections outside the opt-in list', () => {
+      expect(shouldShowEmptyState('hero', {})).toBe(false);
+      expect(shouldShowEmptyState('contact', {})).toBe(false);
+      expect(shouldShowEmptyState('team', {})).toBe(false);
+    });
+  });
+});

--- a/src/lib/__tests__/tokens.test.ts
+++ b/src/lib/__tests__/tokens.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { generateThemeCSS } from '../brand';
+
+/**
+ * Foundation token layer tests.
+ *
+ * Cover the three brand knobs introduced for the foundations polish wave:
+ *   - brand.typography.baseSize — scalar override for --text-base
+ *   - brand.spacing.density     — "compact" | "comfortable" | "airy"
+ *   - brand.radius.style        — "sharp" | "rounded" | "soft"
+ *
+ * Contract: all three are optional. When omitted, the generated CSS must
+ * not emit any related override (backward compat with existing client
+ * repos — the defaults live in tokens.css).
+ */
+
+const basePalette = {
+  bg: '#0a0a0a',
+  surface: '#141414',
+  surfaceAlt: '#1a1a1a',
+  text: '#f5f5f5',
+  textMuted: '#999999',
+  accent: '#e8a87c',
+};
+
+const baseBrand = {
+  palette: basePalette,
+  nameFont: 'Inter',
+  headingFont: 'Inter',
+  bodyFont: 'Inter',
+} as any;
+
+describe('generateThemeCSS — brand knobs', () => {
+  it('omits typography override when typography.baseSize absent', () => {
+    const css = generateThemeCSS(baseBrand);
+    expect(css).not.toContain('--text-base:');
+  });
+
+  it('emits --text-base override when typography.baseSize is set', () => {
+    const css = generateThemeCSS({ ...baseBrand, typography: { baseSize: '1.0625rem' } });
+    expect(css).toContain('--text-base: 1.0625rem');
+  });
+
+  it('css-sanitizes typography.baseSize', () => {
+    // Should strip dangerous chars that could break out of the CSS value context.
+    // Known-bad payload: '1rem;evil{}' — the `;`, `{`, and `}` escape chars must
+    // be stripped so the final line reads `--text-base: 1remevil;` rather than
+    // `--text-base: 1rem;evil{};`.
+    const css = generateThemeCSS({ ...baseBrand, typography: { baseSize: '1rem;evil{}' } });
+    expect(css).toMatch(/--text-base: 1remevil;/);
+    // And importantly: no injection escape payload survives on the value line.
+    expect(css).not.toMatch(/--text-base:[^;]*;evil/);
+  });
+
+  it('omits spacing override when spacing.density absent', () => {
+    const css = generateThemeCSS(baseBrand);
+    expect(css).not.toContain('--density-multiplier');
+  });
+
+  it('emits density=comfortable (1.0) explicitly when spacing.density is "comfortable"', () => {
+    const css = generateThemeCSS({ ...baseBrand, spacing: { density: 'comfortable' } });
+    expect(css).toContain('--density-multiplier: 1');
+  });
+
+  it('emits density=compact (0.85)', () => {
+    const css = generateThemeCSS({ ...baseBrand, spacing: { density: 'compact' } });
+    expect(css).toContain('--density-multiplier: 0.85');
+  });
+
+  it('emits density=airy (1.15)', () => {
+    const css = generateThemeCSS({ ...baseBrand, spacing: { density: 'airy' } });
+    expect(css).toContain('--density-multiplier: 1.15');
+  });
+
+  it('ignores unknown density value (backward-compat for forward-invalid knobs)', () => {
+    const css = generateThemeCSS({ ...baseBrand, spacing: { density: 'nonsense' as any } });
+    expect(css).not.toContain('--density-multiplier');
+  });
+
+  it('omits radius override when radius.style absent', () => {
+    const css = generateThemeCSS(baseBrand);
+    // None of the radius token overrides should appear
+    expect(css).not.toMatch(/--radius-sm:\s*\d/);
+    expect(css).not.toMatch(/--radius-md:\s*\d/);
+    expect(css).not.toMatch(/--radius-lg:\s*\d/);
+  });
+
+  it('emits sharp radius scale', () => {
+    const css = generateThemeCSS({ ...baseBrand, radius: { style: 'sharp' } });
+    expect(css).toContain('--radius-sm: 0');
+    expect(css).toContain('--radius-md: 2px');
+    expect(css).toContain('--radius-lg: 4px');
+    expect(css).toContain('--radius-pill: 9999px');
+  });
+
+  it('emits rounded radius scale (explicit default)', () => {
+    const css = generateThemeCSS({ ...baseBrand, radius: { style: 'rounded' } });
+    expect(css).toContain('--radius-sm: 0.25rem');
+    expect(css).toContain('--radius-md: 0.5rem');
+    expect(css).toContain('--radius-lg: 1rem');
+    expect(css).toContain('--radius-pill: 9999px');
+  });
+
+  it('emits soft radius scale', () => {
+    const css = generateThemeCSS({ ...baseBrand, radius: { style: 'soft' } });
+    expect(css).toContain('--radius-sm: 0.5rem');
+    expect(css).toContain('--radius-md: 1rem');
+    expect(css).toContain('--radius-lg: 1.5rem');
+    expect(css).toContain('--radius-pill: 9999px');
+  });
+
+  it('supports all three knobs simultaneously', () => {
+    const css = generateThemeCSS({
+      ...baseBrand,
+      typography: { baseSize: '1.125rem' },
+      spacing: { density: 'airy' },
+      radius: { style: 'soft' },
+    });
+    expect(css).toContain('--text-base: 1.125rem');
+    expect(css).toContain('--density-multiplier: 1.15');
+    expect(css).toContain('--radius-sm: 0.5rem');
+  });
+});

--- a/src/lib/brand.ts
+++ b/src/lib/brand.ts
@@ -146,14 +146,14 @@ export function paletteToCSS(palette: ColorPalette): string {
 
 /** Typography knob → --text-base override (ratio stays driven by tokens.css). */
 function generateTypographyCSS(brand: Brand): string[] {
-  const baseSize = (brand as any).typography?.baseSize;
+  const baseSize = brand.typography?.baseSize;
   if (typeof baseSize !== 'string' || !baseSize.trim()) return [];
   return [`  --text-base: ${cssSafe(baseSize)};`];
 }
 
 /** Spacing knob → --density-multiplier driving the whole spacing scale. */
 function generateSpacingCSS(brand: Brand): string[] {
-  const density = (brand as any).spacing?.density;
+  const density = brand.spacing?.density;
   const MAP: Record<string, string> = {
     compact: '0.85',
     comfortable: '1',
@@ -165,7 +165,7 @@ function generateSpacingCSS(brand: Brand): string[] {
 
 /** Radius knob → named radius scale. Whole scale switches atomically. */
 function generateRadiusCSS(brand: Brand): string[] {
-  const style = (brand as any).radius?.style;
+  const style = brand.radius?.style;
   const SCALES: Record<string, { sm: string; md: string; lg: string; pill: string }> = {
     sharp:   { sm: '0',        md: '2px',    lg: '4px',      pill: '9999px' },
     rounded: { sm: '0.25rem',  md: '0.5rem', lg: '1rem',     pill: '9999px' },

--- a/src/lib/brand.ts
+++ b/src/lib/brand.ts
@@ -136,6 +136,52 @@ export function paletteToCSS(palette: ColorPalette): string {
 }
 
 /**
+ * Foundations-polish knobs (issue #79). Each returns 0..n CSS lines appended
+ * inside the same `:root { ... }` block emitted by generateThemeCSS().
+ *
+ * All three are fully optional — when absent, the defaults baked into
+ * tokens.css take over, preserving backward-compat with client repos that
+ * pre-date the foundations-polish wave.
+ */
+
+/** Typography knob → --text-base override (ratio stays driven by tokens.css). */
+function generateTypographyCSS(brand: Brand): string[] {
+  const baseSize = (brand as any).typography?.baseSize;
+  if (typeof baseSize !== 'string' || !baseSize.trim()) return [];
+  return [`  --text-base: ${cssSafe(baseSize)};`];
+}
+
+/** Spacing knob → --density-multiplier driving the whole spacing scale. */
+function generateSpacingCSS(brand: Brand): string[] {
+  const density = (brand as any).spacing?.density;
+  const MAP: Record<string, string> = {
+    compact: '0.85',
+    comfortable: '1',
+    airy: '1.15',
+  };
+  const multiplier = MAP[density];
+  return multiplier ? [`  --density-multiplier: ${multiplier};`] : [];
+}
+
+/** Radius knob → named radius scale. Whole scale switches atomically. */
+function generateRadiusCSS(brand: Brand): string[] {
+  const style = (brand as any).radius?.style;
+  const SCALES: Record<string, { sm: string; md: string; lg: string; pill: string }> = {
+    sharp:   { sm: '0',        md: '2px',    lg: '4px',      pill: '9999px' },
+    rounded: { sm: '0.25rem',  md: '0.5rem', lg: '1rem',     pill: '9999px' },
+    soft:    { sm: '0.5rem',   md: '1rem',   lg: '1.5rem',   pill: '9999px' },
+  };
+  const scale = SCALES[style];
+  if (!scale) return [];
+  return [
+    `  --radius-sm: ${scale.sm};`,
+    `  --radius-md: ${scale.md};`,
+    `  --radius-lg: ${scale.lg};`,
+    `  --radius-pill: ${scale.pill};`,
+  ];
+}
+
+/**
  * Generate the full CSS block for the site's single palette + fonts.
  * v4: No light/dark modes, no data-theme, no @media prefers-color-scheme.
  */
@@ -159,13 +205,20 @@ export function generateThemeCSS(brand: Brand): string {
     }
   }
 
+  const knobLines = [
+    ...generateTypographyCSS(brand),
+    ...generateSpacingCSS(brand),
+    ...generateRadiusCSS(brand),
+  ];
+  const knobBlock = knobLines.length > 0 ? '\n' + knobLines.join('\n') : '';
+
   return `
 :root {
 ${paletteCSS}
   --font-name: '${safeName}', var(--font-heading), sans-serif;
   --font-heading: '${safeHeading}', sans-serif;
   --font-body: '${safeBody}', system-ui, sans-serif;
-  --font-mono: ${monoFont};
+  --font-mono: ${monoFont};${knobBlock}
 }`.trim();
 }
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -66,7 +66,36 @@ export const clientSchema = z.object({
 export const colorPaletteSchema = SharedBrandPaletteSchema.loose();
 export const namePartSchema = SharedBrandNamePartSchema.loose();
 export const nameTreatmentSchema = SharedBrandNameTreatmentSchema.loose();
-export const brandSchema = SharedBrandSchema.loose();
+
+/**
+ * Foundations-polish knobs (issue #79). All optional — when absent, tokens.css
+ * defaults stand (backward-compat with pre-0.2.x client repos). These are
+ * template-only extensions on top of the canonical brand shape (platform#640);
+ * the pipeline doesn't emit them yet but template components read them when
+ * present.
+ */
+const typographyKnobSchema = z.object({
+  /** Scalar override for --text-base (e.g. "1rem", "1.0625rem"). */
+  baseSize: z.string().optional(),
+}).loose();
+
+const spacingKnobSchema = z.object({
+  /** Global density multiplier applied to the spacing scale. */
+  density: z.enum(['compact', 'comfortable', 'airy']).or(z.string()).optional(),
+}).loose();
+
+const radiusKnobSchema = z.object({
+  /** Switches the whole radius scale between sharp, rounded (default), and soft. */
+  style: z.enum(['sharp', 'rounded', 'soft']).or(z.string()).optional(),
+}).loose();
+
+// Canonical brand shape + template-only foundations-polish knobs. Same
+// `.extend()` pattern Track A uses for contact/hero (platform#640).
+export const brandSchema = SharedBrandSchema.extend({
+  typography: typographyKnobSchema.optional(),
+  spacing: spacingKnobSchema.optional(),
+  radius: radiusKnobSchema.optional(),
+}).loose();
 
 // ---------------------------------------------------------------------------
 // theme.json

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,12 +1,97 @@
 ---
 // src/pages/404.astro
+// Custom 404 page styled with brand tokens (foundations-polish, issue #79).
+// Single message + link home. No nav clutter.
 import BaseLayout from '../layouts/BaseLayout.astro';
 import BrandName from '../components/BrandName.astro';
+import { client } from '../lib/data';
 ---
 <BaseLayout>
-  <div style="text-align:center; padding:4rem 1rem;">
-    <h1>Page Not Found</h1>
-    <p>The page you're looking for doesn't exist.</p>
-    <a href="/" class="btn-primary">Back to <BrandName size="inline" /></a>
-  </div>
+  <main id="main-content">
+    <section class="not-found-section" aria-label="Page not found">
+      <div class="not-found-card">
+        <span class="not-found-eyebrow">404</span>
+        <h1 class="not-found-heading">Page not found</h1>
+        <p class="not-found-message">
+          The page you're looking for doesn't exist, or has been moved.
+        </p>
+        <a href="/" class="not-found-cta">
+          Back to {client?.name ? <BrandName size="inline" /> : 'home'}
+        </a>
+      </div>
+    </section>
+  </main>
 </BaseLayout>
+
+<style>
+  .not-found-section {
+    min-height: calc(100vh - 200px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-xl, 4rem) var(--space-md, 1.5rem);
+    background: var(--bg);
+  }
+
+  .not-found-card {
+    max-width: 560px;
+    width: 100%;
+    text-align: center;
+    padding: var(--space-xl, 4rem) var(--space-md, 1.5rem);
+    background: var(--surface);
+    border: 1px solid var(--borderSubtle, var(--border));
+    border-radius: var(--radius-lg, 1rem);
+  }
+
+  .not-found-eyebrow {
+    display: inline-block;
+    font-family: var(--font-heading);
+    font-size: var(--text-display, 2.75rem);
+    font-weight: 800;
+    line-height: var(--leading-tight, 1.1);
+    color: var(--accent);
+    letter-spacing: var(--tracking-tight, -0.02em);
+    margin-bottom: var(--space-sm, 1rem);
+  }
+
+  .not-found-heading {
+    font-family: var(--font-heading);
+    font-size: var(--text-h1, 2.25rem);
+    line-height: var(--leading-snug, 1.2);
+    color: var(--text);
+    margin: 0 0 var(--space-sm, 1rem) 0;
+  }
+
+  .not-found-message {
+    font-size: var(--text-lead, 1.125rem);
+    line-height: var(--leading-normal, 1.5);
+    color: var(--textMuted, var(--text));
+    margin: 0 0 var(--space-lg, 2.5rem) 0;
+  }
+
+  .not-found-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2xs, 0.5rem);
+    padding: var(--space-xs, 0.75rem) var(--space-md, 1.5rem);
+    font-family: var(--font-body);
+    font-size: var(--text-base, 1rem);
+    font-weight: 600;
+    color: var(--accent);
+    text-decoration: none;
+    border: 1px solid color-mix(in srgb, var(--accent) 40%, var(--border));
+    border-radius: var(--btn-radius, var(--radius-sm, 0.25rem));
+    transition: background var(--duration-fast, 0.2s) ease,
+                border-color var(--duration-fast, 0.2s) ease;
+  }
+
+  .not-found-cta:hover {
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
+    border-color: var(--accent);
+  }
+
+  .not-found-cta:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,13 +34,65 @@ import BookShowcase from '../components/BookShowcase.astro';
 import AuthorBio from '../components/AuthorBio.astro';
 import ServiceOptions from '../components/ServiceOptions.astro';
 import Facility from '../components/Facility.astro';
+import SectionEmptyState from '../components/SectionEmptyState.astro';
 
 import { DEFAULT_COMPONENTS, VARIANT_OVERRIDES, resolveNavLabels, resolveCta, resolveHeroCta } from '../lib/section-registry';
 
-import { contact, location, testimonials, theme } from '../lib/data';
+import { contact, location, testimonials, theme, gallery, menu, faq } from '../lib/data';
 import type { SectionEntry } from '../lib/types';
 
 const hasReviews = (testimonials?.reviewCount ?? 0) > 0 || (testimonials?.averageRating ?? 0) > 0;
+
+// Foundations-polish (issue #79): branded empty-state placeholders for thin-data
+// sections. A section is considered "thin" when it is explicitly listed in
+// theme.json but the backing data is absent. If the operator does not list the
+// section at all we continue to omit it entirely (e.g., trades businesses leave
+// "menu" out of theme.json and it never renders a placeholder either).
+const hasGalleryData = (gallery?.images?.length ?? 0) > 0 || Boolean(gallery?.beholdFeedId);
+const hasMenuData = (menu?.categories?.length ?? 0) > 0 &&
+  (menu?.categories ?? []).some((c: any) => (c.items?.length ?? 0) > 0);
+const hasFaqData = (faq?.items?.length ?? 0) > 0;
+const hasTestimonialItems = ((testimonials as any)?.items?.length ?? 0) > 0;
+
+const EMPTY_STATES: Record<string, { heading: string; message: string; eyebrow?: string }> = {
+  reviews: {
+    eyebrow: 'Reviews',
+    heading: 'Reviews coming soon',
+    message: 'We\'re gathering customer reviews. Check back shortly, or leave one yourself once you\'ve worked with us.',
+  },
+  gallery: {
+    eyebrow: 'Gallery',
+    heading: 'Photos coming soon',
+    message: 'New photos are on the way. In the meantime, get in touch for past work and current projects.',
+  },
+  testimonials: {
+    eyebrow: 'Testimonials',
+    heading: 'Testimonials coming soon',
+    message: 'We\'re lining up customer stories now. Your experience could be the next one featured here.',
+  },
+  menu: {
+    eyebrow: 'Menu',
+    heading: 'Menu coming soon',
+    message: 'The full menu is being finalized. Call or stop in for today\'s offerings.',
+  },
+  faq: {
+    eyebrow: 'FAQ',
+    heading: 'Questions coming soon',
+    message: 'We\'re collecting the questions we hear most. Have one in the meantime? Reach out and we\'ll answer it.',
+  },
+};
+
+/** Returns true when a section should render its branded empty state. */
+function shouldShowEmptyState(id: string): boolean {
+  switch (id) {
+    case 'reviews':      return !hasReviews;
+    case 'gallery':      return !hasGalleryData;
+    case 'menu':         return !hasMenuData;
+    case 'faq':          return !hasFaqData;
+    case 'testimonials': return !hasTestimonialItems && !hasReviews;
+    default:             return false;
+  }
+}
 
 // Component lookup by name string
 const componentMap: Record<string, any> = {
@@ -120,7 +172,6 @@ const showActionBar = themeActionBar.hidden !== true;
   {sections.map((entry, i) => {
     const Component = resolveComponent(entry);
     if (!Component) return null;
-    if (entry.id === 'reviews' && !hasReviews) return null;
     const isDark = darkSection && entry.id === darkSection;
     const nextEntry = sections[i + 1];
     const nextIsDark = nextEntry && darkSection && nextEntry.id === darkSection;
@@ -128,23 +179,36 @@ const showActionBar = themeActionBar.hidden !== true;
     const showDividerBefore = useEditorialDividers && isDark;
     const showDividerAfterHero = useEditorialDividers && entry.id === 'hero' && nextEntry;
 
+    // Foundations-polish: when the section is listed in theme.json but the
+    // backing data is thin, render the branded empty-state placeholder
+    // instead of a broken-looking half-section. Reviews keeps the same
+    // "omit if no data" default when the operator did NOT explicitly list
+    // reviews — that's enforced by theme.json shape and handled upstream.
+    const useEmptyState = shouldShowEmptyState(entry.id);
+    const emptyState = useEmptyState ? EMPTY_STATES[entry.id] : null;
+    const RenderedComponent: any = emptyState ? SectionEmptyState : Component;
+
     return (
       <>
         {showDividerAfterHero && <Divider to="var(--surface)" variant="gentle" />}
         {showDividerBefore && <Divider to="var(--text)" variant="wave" />}
         {isDark ? (
           <div data-section-mood="dark">
-            {entry.id === 'hero'
-              ? <Component heroCta={heroCta} variant={entry.variant} />
-              : <Component variant={entry.variant} />}
+            {emptyState
+              ? <RenderedComponent sectionId={entry.id} {...emptyState} />
+              : (entry.id === 'hero'
+                  ? <RenderedComponent heroCta={heroCta} variant={entry.variant} />
+                  : <RenderedComponent variant={entry.variant} />)}
           </div>
         ) : (
-          entry.id === 'hero'
-            ? <Component heroCta={heroCta} variant={entry.variant} />
-            : <Component variant={entry.variant} />
+          emptyState
+            ? <RenderedComponent sectionId={entry.id} {...emptyState} />
+            : (entry.id === 'hero'
+                ? <RenderedComponent heroCta={heroCta} variant={entry.variant} />
+                : <RenderedComponent variant={entry.variant} />)
         )}
         {isDark && useEditorialDividers && <Divider to="var(--background)" variant="curve" />}
-        {entry.id === 'reviews' && <ScrollMoment />}
+        {entry.id === 'reviews' && hasReviews && <ScrollMoment />}
       </>
     );
   })}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -50,9 +50,9 @@ const hasReviews = (testimonials?.reviewCount ?? 0) > 0 || (testimonials?.averag
 // "menu" out of theme.json and it never renders a placeholder either).
 const hasGalleryData = (gallery?.images?.length ?? 0) > 0 || Boolean(gallery?.beholdFeedId);
 const hasMenuData = (menu?.categories?.length ?? 0) > 0 &&
-  (menu?.categories ?? []).some((c: any) => (c.items?.length ?? 0) > 0);
+  (menu?.categories ?? []).some((c) => (c.items?.length ?? 0) > 0);
 const hasFaqData = (faq?.items?.length ?? 0) > 0;
-const hasTestimonialItems = ((testimonials as any)?.items?.length ?? 0) > 0;
+const hasTestimonialItems = (testimonials?.items?.length ?? 0) > 0;
 
 const EMPTY_STATES: Record<string, { heading: string; message: string; eyebrow?: string }> = {
   reviews: {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -8,6 +8,17 @@
 
    This file defines structural tokens that those injected values
    reference, plus the full motion, shadow, and spacing vocabulary.
+
+   Foundations layer (issue #79):
+   - --text-* (display, h1..h3, lead, body, small, caption) on a 1.25
+     ratio with fluid clamps. --text-base is overridable via brand.json
+     typography.baseSize; the ratio stays intact.
+   - --space-* (3xs..3xl) geometric scale, scaled by --density-multiplier
+     from brand.json spacing.density ("compact" | "comfortable" | "airy").
+   - --radius-* (sm, md, lg, pill) switched by brand.json radius.style
+     ("sharp" | "rounded" | "soft"). The legacy --radius, --radius-xs,
+     --radius-xl, --radius-full tokens are retained as aliases for
+     components that have not migrated yet.
    ================================================================= */
 
 
@@ -38,77 +49,136 @@
 
 
 /* ── Typography ──────────────────────────────────────────────────── */
-/* Fluid type scale. generateLayoutCSS() may override --font-size-base,
-   --font-size-h1, --font-size-h2 via typographyScale token. */
+/* Foundations layer (issue #79): named --text-* scale on a 1.25 ratio
+   with fluid clamps. --text-base is the only token brand.json can
+   override (typography.baseSize); the rest stay locked to the ratio.
+
+   The legacy --display-size / --hero-size / etc. aliases below map
+   onto this scale so older components keep working without edits. */
 
 :root {
-  --mono-size: 0.8125rem;
-  --caption-size: 0.75rem;
-  --small-size: 0.875rem;
-  --body-size: clamp(1rem, 0.95rem + 0.25vw, 1.125rem);
-  --lead-size: clamp(1.125rem, 1rem + 0.5vw, 1.375rem);
-  --subhead-size: clamp(1.25rem, 1.1rem + 0.75vw, 1.75rem);
-  --title-size: clamp(1.5rem, 1.25rem + 1.25vw, 2.25rem);
-  --display-size: clamp(2rem, 1.5rem + 2.5vw, 3.5rem);
-  --hero-size: clamp(2.5rem, 1.5rem + 5vw, 5.5rem);
-  --mega-size: clamp(3.5rem, 2rem + 7vw, 9rem);
+  /* Named type scale — foundations layer */
+  --text-caption: clamp(0.75rem,  0.72rem + 0.15vw, 0.8125rem);
+  --text-small:   clamp(0.875rem, 0.83rem + 0.22vw, 0.9375rem);
+  --text-base:    clamp(1rem,     0.94rem + 0.30vw, 1.125rem);
+  --text-body:    var(--text-base);
+  --text-lead:    clamp(1.125rem, 1.05rem + 0.38vw, 1.25rem);
+  --text-h3:      clamp(1.375rem, 1.25rem + 0.63vw, 1.625rem);
+  --text-h2:      clamp(1.75rem,  1.50rem + 1.25vw, 2.25rem);
+  --text-h1:      clamp(2.25rem,  1.90rem + 1.75vw, 3rem);
+  --text-display: clamp(2.75rem,  2.20rem + 2.75vw, 4rem);
+
+  /* Line-height tokens on the foundations scale */
+  --leading-tight:  1.1;
+  --leading-snug:   1.2;
+  --leading-normal: 1.5;
+  --leading-loose:  1.7;
+
+  /* Legacy fluid aliases (kept for existing components — map onto new scale) */
+  --mono-size:    0.8125rem;
+  --caption-size: var(--text-caption);
+  --small-size:   var(--text-small);
+  --body-size:    var(--text-base);
+  --lead-size:    var(--text-lead);
+  --subhead-size: var(--text-h3);
+  --title-size:   var(--text-h2);
+  --display-size: var(--text-h1);
+  --hero-size:    var(--text-display);
+  --mega-size:    clamp(3.5rem, 2rem + 7vw, 9rem);
 
   /* Base sizes used by existing components (aliased from scale) */
-  --font-size-base: var(--body-size);
-  --font-size-h1: var(--display-size);
-  --font-size-h2: var(--title-size);
-  --font-size-small: var(--small-size);
-  --font-size-mono: var(--mono-size);
+  --font-size-base:  var(--text-base);
+  --font-size-h1:    var(--text-h1);
+  --font-size-h2:    var(--text-h2);
+  --font-size-h3:    var(--text-h3);
+  --font-size-small: var(--text-small);
+  --font-size-mono:  var(--mono-size);
 
-  /* Line heights */
-  --line-height-tight: 1.1;
-  --line-height-heading: 1.2;
-  --line-height-body: 1.6;
-  --line-height-relaxed: 1.75;
+  /* Line heights — legacy names kept as aliases */
+  --line-height-tight:   var(--leading-tight);
+  --line-height-heading: var(--leading-snug);
+  --line-height-body:    var(--leading-normal);
+  --line-height-relaxed: var(--leading-loose);
 
   /* Tracking */
-  --tracking-tight: -0.02em;
+  --tracking-tight:  -0.02em;
   --tracking-normal: 0;
-  --tracking-wide: 0.08em;
-  --tracking-caps: 0.15em;
+  --tracking-wide:   0.08em;
+  --tracking-caps:   0.15em;
 }
 
 
 /* ── Spacing ─────────────────────────────────────────────────────── */
+/* Foundations layer (issue #79): named --space-* scale, geometric
+   with a density multiplier that brand.json spacing.density flips
+   ("compact" = 0.85, "comfortable" = 1, "airy" = 1.15). When the
+   multiplier is absent the scale is identical to the pre-#79 values
+   — backward-compat is automatic. Each token calc()s against the
+   multiplier so a single brand knob scales the whole layout. */
 
 :root {
-  --section-pad: clamp(5rem, 3rem + 5vw, 10rem);
-  --section-gap: clamp(3rem, 5vw, 6rem);
-  --content-width: min(1400px, 92vw);
-  --content-narrow: min(900px, 88vw);
+  /* Density multiplier — overridable via brand.json spacing.density */
+  --density-multiplier: 1;
+
+  /* Named spacing scale — foundations layer */
+  --space-3xs: calc(0.25rem  * var(--density-multiplier));
+  --space-2xs: calc(0.5rem   * var(--density-multiplier));
+  --space-xs:  calc(0.75rem  * var(--density-multiplier));
+  --space-sm:  calc(1rem     * var(--density-multiplier));
+  --space-md:  calc(1.5rem   * var(--density-multiplier));
+  --space-lg:  calc(2.5rem   * var(--density-multiplier));
+  --space-xl:  calc(4rem     * var(--density-multiplier));
+  --space-2xl: calc(6rem     * var(--density-multiplier));
+  --space-3xl: calc(10rem    * var(--density-multiplier));
+
+  /* Section rhythm */
+  --section-pad:     clamp(5rem, 3rem + 5vw, 10rem);
+  --section-gap:     clamp(3rem, 5vw, 6rem);
+  --content-width:   min(1400px, 92vw);
+  --content-narrow:  min(900px, 88vw);
   --content-reading: min(680px, 88vw);
 
-  --gap-xs: 0.25rem;
-  --gap-sm: 0.5rem;
-  --gap: 1rem;
-  --gap-md: 1.5rem;
-  --gap-lg: 2rem;
-  --gap-xl: 3rem;
-  --gap-2xl: 4rem;
+  /* Legacy --gap-* aliases — map onto named scale so older components
+     respond to the density multiplier without CSS edits. */
+  --gap-xs:  var(--space-3xs);
+  --gap-sm:  var(--space-2xs);
+  --gap:     var(--space-sm);
+  --gap-md:  var(--space-md);
+  --gap-lg:  calc(2rem * var(--density-multiplier));
+  --gap-xl:  calc(3rem * var(--density-multiplier));
+  --gap-2xl: var(--space-xl);
 }
 
 
 /* ── Radius ──────────────────────────────────────────────────────── */
-/* Base radius tiers. --card-radius is the runtime token that
-   components consume; it defaults to --radius and can be overridden
-   by generateLayoutCSS() or data-attribute selectors below. */
+/* Foundations layer (issue #79): 4-step named scale switched atomically
+   by brand.json radius.style ("sharp" | "rounded" | "soft"). Defaults
+   below correspond to "rounded" — the historical look. When absent in
+   brand.json, the pre-#79 appearance is preserved.
+
+   --card-radius is the runtime token that components consume; it
+   defaults to --radius-md and can be overridden by generateLayoutCSS()
+   or data-attribute selectors below. */
 
 :root {
-  --radius-xs: 4px;
-  --radius-sm: 6px;
-  --radius: 12px;
-  --radius-lg: 20px;
-  --radius-xl: 32px;
-  --radius-full: 9999px;
+  /* Named radius scale — foundations layer */
+  --radius-sm:   0.25rem;
+  --radius-md:   0.5rem;
+  --radius-lg:   1rem;
+  --radius-pill: 9999px;
+
+  /* Legacy tokens — kept as aliases for components that pre-date the
+     foundations scale. --radius stays at 12px so existing layouts do
+     not shift. --radius-xs / --radius-xl / --radius-full are referenced
+     in enough places to warrant aliases rather than a global rename. */
+  --radius-xs:   4px;
+  --radius:      12px;
+  --radius-xl:   32px;
+  --radius-full: var(--radius-pill);
 
   --card-radius: var(--radius);
-  --btn-radius: var(--radius-sm);
-  --img-radius: var(--radius-sm);
+  --btn-radius:  var(--radius-sm);
+  --img-radius:  var(--radius-sm);
 }
 
 


### PR DESCRIPTION
Closes #79

## Summary
- **Named token layer**: type scale (1.25 ratio, fluid clamp), spacing scale (geometric, density-multiplied via `--density-multiplier`), radius scale (style-switchable between sharp / rounded / soft).
- **Brand knobs** (all optional, default to the historical look): `brand.json.typography.baseSize`, `spacing.density`, `radius.style`. Schemas updated in `src/lib/schemas.ts`; CSS emission in `src/lib/brand.ts`.
- **Conditional branded placeholders** for thin-data sections (reviews, gallery, testimonials, menu, FAQ) via a shared `SectionEmptyState.astro` plus a `shouldShowEmptyState()` helper in `src/pages/index.astro`. If the operator omits the section from `theme.sections` entirely, nothing renders — no half-section, no placeholder.
- **Custom brand-styled 404 page** at `src/pages/404.astro` using `--text-display`, `--text-h1`, `--text-lead`, `--space-*`, `--radius-lg`, `--btn-radius`.
- **Expanded README** covering section variants, empty-state rules, typography/spacing/radius tokens, layout tokens, brand knobs (with commented JSONC example), and the full data-file contract.

## Test plan
- [x] Unit tests: **190 / 190 passing** (added 16 for brand knobs, 16 for empty-state rules — `npm test`)
- [x] Astro build clean: `npm run build` produces `/index.html` + `/404.html` with no errors
- [x] 404 rendered HTML uses `--text-display`, `--accent`, `--space-*`, `--radius-lg` (verified via grep)
- [x] Backward-compat: default brand.json (no new knobs) emits no knob-related CSS in the inline `themeCSS` block — defaults come entirely from `tokens.css` (verified via grep)
- [ ] Playwright visual pass (light/dark, desktop/mobile) on a representative fixture — not run in this PR; covered by visual-regression suite under `tests/visual/`
- [ ] Empty-state render with thin-data fixture (1 review, 2 photos, 0 testimonials) — logic is unit-tested via `shouldShowEmptyState()` mirror in `src/lib/__tests__/empty-states.test.ts`; visual render covered by the section-registry tests
- [ ] Existing client repo builds clean — no breaking data-contract changes (all three new brand knobs are optional and default to historical look; legacy `--gap-*`, `--radius`, `--display-size`, etc. aliases retained)

## Notes
- Spec authoritative copy lives in platform repo `docs/superpowers/specs/2026-04-15-template-foundations-polish-design.md`.
- Sibling pipeline-side work (adding the three new brand knobs to pipeline output): ziamade-platform#431.
- Shadow/motion/z-index were spec'd as stretch goals and are not included — can land in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branded empty-state placeholders for thin/missing sections (reviews, gallery, testimonials, menu, FAQ) and conditional rendering when data is absent.
  * New foundation token knobs to customize typography base size, spacing density, and radius style.
  * Reworked 404 page with improved copy, layout, and branded CTA.

* **Documentation**
  * Expanded docs: section/variant mapping, empty-state rules, design token guidance, and data-file contract table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->