### PR TITLE
fix: zod validation fails loudly instead of silent raw-fallback (platform#649)

### DIFF
--- a/src/lib/__tests__/data-validate.test.ts
+++ b/src/lib/__tests__/data-validate.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'astro/zod';
+import { validate } from '../data-validate';
+
+/**
+ * Regression test for platform#649.
+ *
+ * Template-side zod validation used to log a warning and silently fall
+ * back to raw data when a pipeline-produced file failed its schema.
+ * This let the 2026-04-22 shakeout ship 9 separate data-contract gaps
+ * with no visual signal. The build MUST now throw loudly so the
+ * pipeline sees a non-zero exit and the site never deploys.
+ */
+describe('validate (platform#649)', () => {
+  const minimalSchema = z.object({
+    heroImage: z.string(),
+    heroTagline: z.string(),
+  });
+
+  it('returns parsed data when input matches the schema', () => {
+    const raw = { heroImage: '/x.jpg', heroTagline: 'hello' };
+    const out = validate(minimalSchema, raw, 'hero.json');
+    expect(out).toEqual(raw);
+  });
+
+  it('throws when a required field is missing (no silent fallback)', () => {
+    const raw = { heroImage: '/x.jpg' }; // missing heroTagline
+    expect(() => validate(minimalSchema, raw, 'hero.json')).toThrow();
+  });
+
+  it('throws when a field has the wrong type', () => {
+    const raw = { heroImage: 123, heroTagline: 'hello' };
+    expect(() => validate(minimalSchema, raw, 'hero.json')).toThrow();
+  });
+
+  it('error message names the failing file so operators can find it', () => {
+    const raw = { heroImage: '/x.jpg' };
+    expect(() => validate(minimalSchema, raw, 'hero.json')).toThrow(/hero\.json/);
+  });
+
+  it('error message includes at least one issue path so the bad field is identifiable', () => {
+    const raw = { heroImage: '/x.jpg' }; // missing heroTagline
+    try {
+      validate(minimalSchema, raw, 'hero.json');
+      throw new Error('expected validate() to throw');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      expect(message).toMatch(/heroTagline/);
+    }
+  });
+});

--- a/src/lib/__tests__/schemas.test.ts
+++ b/src/lib/__tests__/schemas.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { hoursSchema } from '../schemas';
+
+/**
+ * Regression test for platform#649 round 2.
+ *
+ * The pipeline's template-side hours normalizer (`normalizeHours()` in
+ * `src/lib/hours-parser.ts`) always sets `secondaryHours` to either a
+ * `Record<string, unknown>` or an explicit `null`, never `undefined`.
+ * Meanwhile, `build-from-fixture.ts` in the pipeline package only writes
+ * the `secondaryHours` key to `hours.json` when the business actually has
+ * delivery/takeout hours. For the 3 fixture builds (pwtint, martinezwelding,
+ * dcdrentals) the key is absent, `normalizeHours()` fills in `null`, and the
+ * schema used to reject that because `secondaryHours` was `.optional()` only
+ * (accepts `undefined`, not `null`). Result: every CI fixture build failed
+ * with `expected record, received null`.
+ *
+ * Contract: per the root CLAUDE.md "Pipeline Data Contract", `secondaryHours`
+ * is "delivery/takeout if available" — nullable by design. Widening from
+ * `.optional()` to `.nullable().optional()` aligns the schema with the
+ * documented contract.
+ */
+describe('hoursSchema.secondaryHours (platform#649 round 2)', () => {
+  const baseDay = { day: 'Monday', open: '9:00 AM', close: '5:00 PM' };
+
+  it('accepts a record of secondary hours (restaurant with delivery)', () => {
+    const input = {
+      days: [baseDay],
+      secondaryHours: { delivery: ['Mon: 5 PM – 9 PM'] },
+    };
+    const out = hoursSchema.parse(input);
+    expect(out.secondaryHours).toEqual({ delivery: ['Mon: 5 PM – 9 PM'] });
+  });
+
+  it('accepts secondaryHours omitted entirely', () => {
+    const input = { days: [baseDay] };
+    const out = hoursSchema.parse(input);
+    expect(out.secondaryHours).toBeUndefined();
+  });
+
+  it('accepts secondaryHours: null (post-normalizeHours with no secondary data)', () => {
+    // This is the exact shape that killed CI on PR #94 round 1.
+    const input = { days: [baseDay], secondaryHours: null };
+    expect(() => hoursSchema.parse(input)).not.toThrow();
+  });
+
+  it('accepts secondaryHours: {} (empty record — shipped fixture shape)', () => {
+    // src/data/hours.json on master currently ships with `"secondaryHours": {}`.
+    const input = { days: [baseDay], secondaryHours: {} };
+    const out = hoursSchema.parse(input);
+    expect(out.secondaryHours).toEqual({});
+  });
+
+  it('rejects secondaryHours that is neither record nor null nor undefined', () => {
+    const input = { days: [baseDay], secondaryHours: 'open 24 hours' };
+    expect(() => hoursSchema.parse(input)).toThrow();
+  });
+});

--- a/src/lib/data-validate.ts
+++ b/src/lib/data-validate.ts
@@ -1,0 +1,60 @@
+/**
+ * Build-time data validation helper.
+ *
+ * Fails loudly when any zod-validated data file violates its schema.
+ * This is called from `./data.ts` at module-scope during `astro build`,
+ * so a thrown error aborts the build with a non-zero exit code. The
+ * pipeline sees the failure and will NOT deploy a broken site.
+ *
+ * Prior behavior (until platform#649): a validation failure logged a
+ * warning and returned the raw data, so the template rendered empty /
+ * broken sections with no visible signal. Nine separate pipeline →
+ * template data-contract gaps shipped silently during the 2026-04-22
+ * shakeout before this was fixed. See ziamade-platform#649.
+ *
+ * Schemas in `./schemas.ts` are intentionally permissive (`.loose()`,
+ * most fields `.optional()`), so in practice validate() only throws on
+ * genuine contract violations (missing required fields, wrong types).
+ */
+import type { ZodSchema } from 'astro/zod';
+
+/**
+ * Validate raw data against a zod schema. Returns parsed, typed data on
+ * success. Throws `DataValidationError` on failure — fail loudly at build.
+ */
+export function validate<T>(schema: ZodSchema<T>, raw: unknown, name: string): T {
+  const result = schema.safeParse(raw);
+  if (!result.success) {
+    throw new DataValidationError(name, result.error.issues);
+  }
+  return result.data;
+}
+
+export interface ZodIssueLike {
+  path: (string | number)[];
+  message: string;
+  code?: string;
+}
+
+export class DataValidationError extends Error {
+  readonly file: string;
+  readonly issues: ZodIssueLike[];
+  constructor(file: string, issues: ZodIssueLike[]) {
+    super(formatMessage(file, issues));
+    this.name = 'DataValidationError';
+    this.file = file;
+    this.issues = issues;
+  }
+}
+
+function formatMessage(file: string, issues: ZodIssueLike[]): string {
+  const lines = issues.map((issue) => {
+    const path = issue.path.length ? issue.path.join('.') : '(root)';
+    return `  - ${path}: ${issue.message}`;
+  });
+  return [
+    `[data] ${file} failed schema validation — aborting build.`,
+    `  See src/lib/schemas.ts for the contract. Fix the pipeline output or update the schema.`,
+    ...lines,
+  ].join('\n');
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -4,9 +4,17 @@
  * Every required JSON data file is imported here, validated through its
  * Zod schema, and re-exported as a properly typed constant.
  *
- * Validation is non-fatal: if a schema fails, the raw data is used
- * as-is and a warning is logged. Client data varies widely across
- * sites, so strict validation must never block a build.
+ * Validation is FATAL: if a schema fails, `astro build` aborts with a
+ * non-zero exit code. The pipeline sees the failure and does not deploy
+ * a broken site. Prior behavior silently fell back to raw data and the
+ * template rendered empty / broken sections — see ziamade-platform#649
+ * for the shakeout that motivated the fail-loudly change.
+ *
+ * Schemas in ./schemas.ts are intentionally permissive (`.loose()`,
+ * most fields `.optional()`), so validation only fails on genuine
+ * contract violations (missing required fields, wrong types). If a
+ * pipeline change breaks this file, either fix the writer or loosen
+ * the schema — do NOT reintroduce the silent fallback.
  *
  * Optional data files (tour.json, preview.json, process.json,
  * differentiator.json) are NOT imported here — they use import.meta.glob
@@ -25,8 +33,8 @@
  *   - attributes.json    — Places v2 with attributes
  *   - google-links.json  — only written if links exist
  */
-import type { ZodSchema } from 'astro/zod';
 import { normalizeHours } from './hours-parser';
+import { validate } from './data-validate';
 import {
   clientSchema,
   brandSchema,
@@ -100,17 +108,8 @@ const rawAttributes: unknown = Object.values(attributesFiles)[0]?.default ?? {};
 const googleLinksFiles = import.meta.glob<{ default: unknown }>('../data/google-links.json', { eager: true });
 const rawGoogleLinks: unknown = Object.values(googleLinksFiles)[0]?.default ?? {};
 
-/** Validate with safeParse — warn on failure, never crash the build. */
-function validate<T>(schema: ZodSchema<T>, raw: unknown, name: string): T {
-  const result = schema.safeParse(raw);
-  if (!result.success) {
-    console.warn(`[data] ${name} failed validation (using raw data):`, JSON.stringify(result.error.issues));
-    return raw as T;
-  }
-  return result.data;
-}
-
-// Validated + typed exports
+// Validated + typed exports — validate() throws on schema failure,
+// aborting the Astro build with a non-zero exit code.
 export const client = validate(clientSchema, rawClient, 'client.json');
 export const brand = validate(brandSchema, rawBrand, 'brand.json');
 export const theme = validate(themeSchema, rawTheme, 'theme.json');

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -235,7 +235,12 @@ export const hoursDaySchema = z.object({
 
 export const hoursSchema = z.object({
   days: z.array(hoursDaySchema),
-  secondaryHours: z.record(z.string(), z.unknown()).optional(),
+  // `secondaryHours` is nullable-by-design per the Pipeline Data Contract
+  // ("delivery/takeout if available"). The template's `normalizeHours()`
+  // helper in `hours-parser.ts` always fills in either a Record or an explicit
+  // `null` — never `undefined` — so `.optional()` alone would reject every
+  // fixture build where no secondary hours exist. See platform#649.
+  secondaryHours: z.record(z.string(), z.unknown()).nullable().optional(),
 }).loose();
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes ziamade/ziamade-platform#649
Addresses ziamade/ziamade-platform#640 root-theme section

## Summary

**Chose option 1 (fail the build).** `src/lib/data.ts` used to catch zod failures, log `[data] <file> failed validation (using raw data): ...`, and return the raw object — so pipeline-produced data-contract violations rendered as empty/broken sections with no visual signal. That meta-bug let 9 separate pipeline to template gaps ship silently during the 2026-04-22 shakeout.

Now `validate()` throws `DataValidationError` with the failing file + the full list of zod issues. The error propagates out of `data.ts` at module-scope during `astro build`, so the build exits non-zero and the pipeline sees the failure.

**Spot-check evidence for option 1:**
- `npm run build` against the template's own demo data in `src/data/` — builds clean, no regressions.
- `npm run test` — all 179 existing tests still pass.
- Manually mutated `src/data/hero.json` to an invalid shape (`{ "heroImage": 42, "heroSubtitle": "" }`) — `npm run build` exited with code 1, log surfaced:
  ```
  DataValidationError: [data] hero.json failed schema validation — aborting build.
    See src/lib/schemas.ts for the contract. Fix the pipeline output or update the schema.
    - heroImage: Invalid input: expected string, received number
    - heroTagline: Invalid input: expected string, received undefined
  ```

Schemas in `src/lib/schemas.ts` are intentionally permissive (`.loose()`, most fields `.optional()`), so only genuine contract violations fail — low risk of blocking current client builds whose data conforms to the existing shape.

### Changes

- New `src/lib/data-validate.ts` — exports `validate()` (throws `DataValidationError` on zod failure) plus the error class with `file` + `issues`.
- `src/lib/data.ts` — imports the new `validate()`, removes the local silent-fallback implementation. All 27 data-file `validate()` calls keep their same call shape, so the fail-loudly behavior applies uniformly (hero, brand, hours, theme, client, etc. — not just one file).
- New `src/lib/__tests__/data-validate.test.ts` — 5 vitest cases covering the happy path, two failure modes, the error-message file-name inclusion, and the issue-path surface.

### Out of scope

- Fixing the 9 known contract gaps (tracked at platform#640 Track A + 647/646).
- Pipeline-writer changes.
- Platform admin UI changes.

## Test plan

- [x] `npx vitest run src/lib/__tests__/data-validate.test.ts` — 5 new tests pass
- [x] `npm run test` — 179 / 179 passing
- [x] `npm run build` against valid demo data — clean
- [x] `npm run build` against a mutated `hero.json` — exits code 1, error message names file + fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for data validation scenarios.

* **Bug Fixes**
  * Validation failures now properly halt builds instead of continuing with invalid data, ensuring data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->