### PR TITLE
fix(tests): waitForIdle covers all .gsap-ready hidden states (platform#658)

### DIFF
--- a/tests/visual/helpers/wait-for-idle.ts
+++ b/tests/visual/helpers/wait-for-idle.ts
@@ -3,6 +3,15 @@ import type { Page } from '@playwright/test';
 /**
  * Wait for page to settle: DOM loaded, images loaded, animations frozen.
  * Call before taking screenshots for deterministic results.
+ *
+ * Covers the template's GSAP progressive-enhancement pattern by forcing
+ * all scroll-revealed elements to their final opacity. See below for the
+ * selector list.
+ *
+ * For ad-hoc local Playwright runs (not via this CI harness), prefer
+ * `page.emulateMedia({ reducedMotion: 'reduce' })` — animation-controller
+ * respects that media query and never hides content in the first place,
+ * so no helper is needed.
  */
 export async function waitForIdle(page: Page): Promise<void> {
   // Wait for DOM to be ready (don't use networkidle — it can hang on persistent connections)
@@ -43,14 +52,20 @@ export async function waitForIdle(page: Page): Promise<void> {
     `,
   });
 
-  // Force GSAP-animated elements to be visible (they start at opacity:0)
+  // Force GSAP-animated elements to be visible (they start at opacity:0).
+  // Mirrors every `.gsap-ready` hidden selector in src/styles/animations.css
+  // so fullPage screenshots capture post-reveal content even for sections
+  // below the fold (platform#658).
   await page.addStyleTag({
     content: `
       .gsap-ready .reveal-up,
       .gsap-ready .reveal-left,
       .gsap-ready .reveal-right,
       .gsap-ready .reveal-scale,
-      .gsap-ready .reveal-fade {
+      .gsap-ready .reveal-fade,
+      .gsap-ready .stagger-parent > *,
+      .gsap-ready .split-chars .char,
+      .gsap-ready .split-words .word {
         opacity: 1 !important;
         transform: none !important;
       }


### PR DESCRIPTION
## Summary

Extends `tests/visual/helpers/wait-for-idle.ts` to force-override three additional `.gsap-ready` hidden selectors that the existing helper missed: `.stagger-parent > *`, `.split-chars .char`, `.split-words .word`.

Surfaced by PM during local Track A verify (platform#653 round 1): full-page Playwright screenshots showed Reviews / FAQ / Hours / About sections at `opacity: 0` because their stagger-parent children were never scrolled into view. Filed as `ziamade/ziamade-platform#658` with four candidate fixes; PM picked Option B (extend the helper).

## Scope

- `tests/visual/helpers/wait-for-idle.ts` — one CSS block, three new selectors added to the existing `opacity: 1 !important` override.
- Doc note at the top of the helper documenting the local-ad-hoc alternative: `page.emulateMedia({ reducedMotion: 'reduce' })`. Animation controller already respects that, so manual Playwright sessions outside the CI harness don't need this helper at all.

No production code changes. No animation-controller changes. No new abstractions.

## Test plan

- [x] `npm test` — 184/184 passing (unit tests unaffected; helper isn't unit-tested directly).
- [ ] Visual regression CI baselines may shift for fixtures that use stagger-parent children below the fold — expected, and the new baselines will be more faithful to the post-reveal state.

## Why not a different option

Pipeline#658 lists four solutions; the engineer-lead scoping comment and PM's decision are both there. TL;DR:
- **Option A** (`emulateMedia` in local tests) — zero code. Covered by the new doc note for ad-hoc use.
- **Option C** (query-param bypass in animation-controller) — adds a production code path for test support, inverts the dependency direction. Rejected.
- **Option D** (A + B) — redundant; A isn't code.

Closes ziamade/ziamade-platform#658