### PR TITLE
feat(template): About component reads about.image with logo fallback (#99, consumer of platform#681)

### DIFF
--- a/src/lib/__tests__/about-map.test.ts
+++ b/src/lib/__tests__/about-map.test.ts
@@ -26,4 +26,40 @@ describe('AboutMap component', () => {
     expect(aboutSrc).toContain('about-placeholder');
     expect(aboutSrc).toContain('!aboutImage && !logoUrl');
   });
+
+  /**
+   * Regression tests for platform#681 / template#99.
+   *
+   * Platform PR #688 populates `about.image` with a curated "about hero"
+   * photo (people / job-site shots, never the hero photo). The About
+   * component must render that image when present and fall back to the
+   * logo when absent. Pre-#688 client sites have no `about.image`, so
+   * the logo fallback is what keeps them visually identical.
+   */
+  describe('about.image consumer (platform#681)', () => {
+    it('reads about.image from the data module', () => {
+      expect(aboutSrc).toContain("const aboutImage = about.image || '';");
+    });
+
+    it('renders the about-portrait block when aboutImage is present', () => {
+      expect(aboutSrc).toContain('{aboutImage && (');
+      expect(aboutSrc).toContain('class="about-portrait"');
+      expect(aboutSrc).toContain('src={aboutImage}');
+    });
+
+    it('falls back to logo only when aboutImage is absent', () => {
+      // The fallback branch must gate on `!aboutImage` so existing sites
+      // without the new field still render the brand logo placeholder.
+      expect(aboutSrc).toContain('{!aboutImage && logoUrl && (');
+      expect(aboutSrc).toContain('class="about-logo"');
+    });
+
+    it('keeps the initials placeholder when neither image nor logo exist', () => {
+      // Pre-existing fallback chain stays intact: about.image → logo →
+      // initials placeholder. Track A canonical aboutSchema allows image
+      // to be absent, so this chain must hold.
+      expect(aboutSrc).toContain('!aboutImage && !logoUrl');
+      expect(aboutSrc).toContain('about-placeholder-initials');
+    });
+  });
 });

--- a/src/lib/__tests__/schemas.test.ts
+++ b/src/lib/__tests__/schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { contactSchema, hoursSchema } from '../schemas';
+import { aboutSchema, contactSchema, hoursSchema } from '../schemas';
 
 /**
  * Regression test for platform#675.
@@ -99,5 +99,44 @@ describe('hoursSchema.secondaryHours (platform#649 round 2)', () => {
   it('rejects secondaryHours that is neither record nor null nor undefined', () => {
     const input = { days: [baseDay], secondaryHours: 'open 24 hours' };
     expect(() => hoursSchema.parse(input)).toThrow();
+  });
+});
+
+/**
+ * Regression test for platform#681 / template#99.
+ *
+ * Platform PR #688 extends the pipeline's `about.json` with an optional
+ * `image` field. The media-curator's about-hero selector prefers people
+ * and job-site photos (never the hero photo, fallback to highest-quality
+ * non-hero at quality >= 0.6) and writes the asset path into
+ * `about.image`. `AboutMap.astro` reads it and renders an `<img>` when
+ * present, falling back to the brand logo when absent.
+ *
+ * Existing client sites built before platform#688 don't have this field
+ * in their `about.json`. Lock in both shapes at the schema boundary so
+ * a future "require image" refactor can't break backward compatibility.
+ */
+describe('aboutSchema.image (platform#681 / #99)', () => {
+  it('accepts about.json without image (pre-platform#688 shape)', () => {
+    const input = { heading: 'About Us', text: 'We do good work.' };
+    const out = aboutSchema.parse(input);
+    expect(out.heading).toBe('About Us');
+    expect(out.text).toBe('We do good work.');
+    expect(out.image).toBeUndefined();
+  });
+
+  it('accepts about.json with image (post-platform#688 shape)', () => {
+    const input = {
+      heading: 'About Us',
+      text: 'We do good work.',
+      image: '/assets/images/about-hero.webp',
+    };
+    const out = aboutSchema.parse(input);
+    expect(out.image).toBe('/assets/images/about-hero.webp');
+  });
+
+  it('rejects image when it is not a string', () => {
+    const input = { heading: 'About', text: 'x', image: 42 };
+    expect(() => aboutSchema.parse(input)).toThrow();
   });
 });


### PR DESCRIPTION
Closes #99

## Summary

- AboutMap.astro already reads `about.image` and renders `<OptimizedImg>` when present, with logo fallback and initials placeholder chain intact. That wiring shipped incrementally (`5fc99bd` → `c4b43c8`) before this issue was filed.
- `aboutSchema` already accepts `image: z.string().optional()` via Track A canonical sync (PR #95, platform#640).
- What this PR adds is the regression test layer so the already-shipped behavior doesn't silently regress: schema-level tests for with/without `image`, and component-source tests locking in the conditional render order (image → logo → initials).

## Context

Consumer of platform PR #688 (merged), which extends the pipeline's `about.json` with an optional `image` field. Pipeline-side media-curator picks an about-hero photo (people / job-site shots preferred, never the hero, fallback to highest-quality non-hero at quality >= 0.6). Pre-#688 client sites lack the field and must keep rendering the brand logo placeholder — covered explicitly.

## Test plan

- [x] `npm test` green — 236 / 236 passing (25 test files, up from 229 with 7 new assertions).
- [x] `npm run build` clean with `about.json` missing the `image` field (current repo demo shape, `{"heading":"","text":""}`).
- [x] `npm run build` clean with `about.json` populated (`heading + text + image`), and generated `dist/index.html` contains `about-portrait` but NOT `about-logo` or `about-placeholder-initials`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for image handling in the About section, including fallback behavior when images are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->