### PR TITLE
feat(template): per-site CSS override hook + --status-open token

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -36,6 +36,13 @@ const previewFiles = import.meta.glob<{ default: PreviewData }>('../data/preview
 const previewData: PreviewData | undefined = Object.values(previewFiles)[0]?.default;
 const inPreview = isPreview(previewData);
 
+// Per-site AI-authored CSS override (spec ziamade-platform#755 MVP).
+// If the client site repo ships src/styles/site.css, its raw contents are
+// inlined LAST in <head> so it wins over template styles by source order.
+// Missing file = empty glob result = no-op (Vite semantics).
+const siteOverrideFiles = import.meta.glob<string>('../styles/site.css', { eager: true, query: '?raw', import: 'default' });
+const siteOverrideCss: string | undefined = Object.values(siteOverrideFiles)[0];
+
 const themeCSS = generateThemeCSS(brand);
 const layout = (theme.layout || {}) as Record<string, string>;
 const layoutCSS = generateLayoutCSS(layout);
@@ -87,6 +94,8 @@ const depth = layout.depth || '';
   <style set:html={fontFaceCSS}></style>
   <style set:html={themeCSS}></style>
   {layoutCSS && <style set:html={layoutCSS}></style>}
+  {/* Per-site override (#755). Inlined last so source order wins. */}
+  {siteOverrideCss && <style set:html={siteOverrideCss}></style>}
   {analytics?.umamiWebsiteId && (
     <script defer src={analytics.umamiScriptUrl} data-website-id={analytics.umamiWebsiteId} />
   )}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -44,6 +44,11 @@
   --status-success: #16a34a;
   --status-error: #dc2626;
   --status-warning: #f59e0b;
+  /* Semantic alias: --status-open is the "currently open / live" green
+     used by the heartbeat-dot indicator. Aliased to --status-success so
+     a future palette change ripples through both. Per-site CSS authored
+     by the css-author skill (ziamade-platform#755) targets this token. */
+  --status-open: var(--status-success);
   --star-color: #f5a623;
 }
 


### PR DESCRIPTION
## Summary

- Adds a guarded `import.meta.glob('../styles/site.css', { query: '?raw' })` hook in `BaseLayout.astro`. When a client site repo ships `src/styles/site.css`, its raw contents are inlined LAST in `<head>` so source-order specificity beats template styles. Missing file = empty glob result = no-op (Vite semantics).
- Adds `--status-open: var(--status-success);` semantic alias to `tokens.css` for the "currently open / live" indicator green. Per-site CSS authored by the upcoming `css-author` skill targets this semantic token rather than the generic `--status-success`.

Companion to the platform-side MVP spec at [`docs/superpowers/specs/2026-04-24-css-author-skill-mvp-design.md`](https://github.com/ziamade/ziamade-platform/blob/master/docs/superpowers/specs/2026-04-24-css-author-skill-mvp-design.md). Supersedes the earlier `spike/755-per-site-css-hook` branch (fresh re-author on current main; spike branch parked, "do not merge" as written).

## Test plan

- [ ] CI green
- [ ] `astro build` against a fixture without `src/styles/site.css` → builds clean, no `<style>` for site override
- [ ] `astro build` against a fixture with `src/styles/site.css` → site override `<style>` renders last in `<head>`
- [ ] `--status-open` resolves to `#16a34a` via `var(--status-success)` (devtools computed style)

## Lands second

Per spec § Template hook promotion: this PR opens first but **lands second**, after the platform-side `css-author` skill PRs are ready. Sequencing: template PR opens → platform-side PRs open → template PR merges → `.template-version` bumped in client repos via `propagate-template.ts` → platform-side PRs merge.

Refs ziamade/ziamade-platform#755

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-site CSS customization to override default styles
  * Added a new "open" status styling token for improved status indication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->