### PR TITLE
feat(template): section-copy overrides, centered process rows, layout-token cascade fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template-dukecitymodern",
-  "version": "4.0.9",
+  "version": "4.0.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/__tests__/layout-css-specificity.test.ts
+++ b/src/__tests__/layout-css-specificity.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { generateLayoutCSS } from '../lib/brand';
+
+const TOKENS = readFileSync(
+  resolve(import.meta.dirname, '../styles/tokens.css'),
+  'utf8',
+);
+
+describe('generateLayoutCSS cascade', () => {
+  it('emits a doubled :root selector so it outranks tokens.css defaults', () => {
+    const css = generateLayoutCSS({ cardRadius: 'round' });
+    expect(css.startsWith(':root:root {')).toBe(true);
+  });
+
+  it('returns empty string when no recognized tokens are set', () => {
+    expect(generateLayoutCSS({})).toBe('');
+    expect(generateLayoutCSS(undefined)).toBe('');
+    expect(generateLayoutCSS({ cardRadius: 'not-a-real-value' })).toBe('');
+  });
+
+  // Regression guard for the silent-no-op bug: every var this function can emit
+  // also has a plain `:root` default in tokens.css. Astro orders the bundled
+  // stylesheet after the inline <style>, so equal specificity meant tokens.css
+  // always won. If someone reverts the selector, this fails.
+  it.each([
+    ['cardRadius', 'round', '--card-radius'],
+    ['buttonStyle', 'pill', '--btn-radius'],
+    ['imageStyle', 'rounded', '--img-radius'],
+    ['shadowStyle', 'dramatic', '--shadow-card'],
+    ['overlayDarkness', 'heavy', '--overlay-darkness'],
+  ])('%s emits %s at higher specificity than the tokens.css default', (key, value, cssVar) => {
+    const css = generateLayoutCSS({ [key]: value });
+    expect(css).toContain(cssVar);
+    // Confirm the collision this test exists to protect against is real.
+    expect(TOKENS).toContain(`${cssVar}:`);
+    expect(css.split('\n')[0]).toBe(':root:root {');
+  });
+
+  it('overlayDarkness heavy resolves to 0.7, not the 0.5 default', () => {
+    expect(generateLayoutCSS({ overlayDarkness: 'heavy' })).toContain('--overlay-darkness: 0.7');
+  });
+});

--- a/src/__tests__/layout-logo-only.test.ts
+++ b/src/__tests__/layout-logo-only.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { themeSchema } from '../lib/schemas';
+
+describe('theme.layout.logoOnly', () => {
+  it('parses when present', () => {
+    const parsed = themeSchema.parse({ layout: { logoOnly: true } });
+    expect(parsed.layout?.logoOnly).toBe(true);
+  });
+
+  it('is optional — existing themes without it still parse', () => {
+    const parsed = themeSchema.parse({ layout: { logoSize: 'lg' } });
+    expect(parsed.layout?.logoOnly).toBeUndefined();
+  });
+
+  it('rejects a non-boolean rather than coercing a truthy string', () => {
+    expect(() => themeSchema.parse({ layout: { logoOnly: 'yes' } })).toThrow();
+  });
+});
+
+describe('theme.sectionCopy', () => {
+  it('parses per-section heading and eyebrow overrides', () => {
+    const parsed = themeSchema.parse({
+      sectionCopy: { services: { heading: 'Classes & Programs', eyebrow: 'What we offer' } },
+    });
+    expect(parsed.sectionCopy?.services.heading).toBe('Classes & Programs');
+    expect(parsed.sectionCopy?.services.eyebrow).toBe('What we offer');
+  });
+
+  it('is optional', () => {
+    expect(themeSchema.parse({}).sectionCopy).toBeUndefined();
+  });
+
+  it('rejects a non-string heading', () => {
+    expect(() => themeSchema.parse({ sectionCopy: { services: { heading: 7 } } })).toThrow();
+  });
+});

--- a/src/__tests__/menu-overrides.test.ts
+++ b/src/__tests__/menu-overrides.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { menuSchema } from '../lib/schemas';
+
+const CATEGORIES = [{ name: 'Classes', items: [{ name: 'Drop-in', price: '$15' }] }];
+
+describe('menuSchema copy overrides', () => {
+  it('parses a restaurant menu with no overrides', () => {
+    const parsed = menuSchema.parse({ categories: CATEGORIES });
+    expect(parsed.heading).toBeUndefined();
+    expect(parsed.cta).toBeUndefined();
+    expect(parsed.categories).toHaveLength(1);
+  });
+
+  it('accepts heading, eyebrow and note overrides', () => {
+    const parsed = menuSchema.parse({
+      categories: CATEGORIES,
+      heading: 'Classes & Pricing',
+      eyebrow: 'What it costs',
+      note: 'Classes are paid per calendar month.',
+    });
+    expect(parsed.heading).toBe('Classes & Pricing');
+    expect(parsed.eyebrow).toBe('What it costs');
+    expect(parsed.note).toBe('Classes are paid per calendar month.');
+  });
+
+  it('accepts a cta override that replaces the Order Online default', () => {
+    const parsed = menuSchema.parse({
+      categories: CATEGORIES,
+      cta: { text: 'Sign the Waiver', href: 'https://example.com/w', note: 'Saves time at the door.' },
+    });
+    expect(parsed.cta).toEqual({
+      text: 'Sign the Waiver',
+      href: 'https://example.com/w',
+      note: 'Saves time at the door.',
+    });
+  });
+
+  it('rejects a non-string heading rather than silently dropping it', () => {
+    expect(() => menuSchema.parse({ categories: CATEGORIES, heading: 42 })).toThrow();
+  });
+});

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -597,6 +597,23 @@ const secondaryText = heroSecondaryCta?.text || (hasServicesSection ? 'Our Servi
     color: rgba(255, 255, 255, 0.9);
   }
 
+  /* The ghost secondary CTA has no fill, so it inherits --text from the page
+     palette. Over a photo backdrop that is a dark label on a bright image —
+     the one element in the overlay hero that was never re-colored for
+     light-on-dark. Primary buttons are unaffected: they paint their own
+     accent fill. */
+  .hero--overlay :global(.btn--ghost),
+  .hero--video :global(.btn--ghost) {
+    color: #ffffff;
+    border-color: rgba(255, 255, 255, 0.55);
+  }
+
+  .hero--overlay :global(.btn--ghost:hover),
+  .hero--video :global(.btn--ghost:hover) {
+    background: rgba(255, 255, 255, 0.14);
+    border-color: rgba(255, 255, 255, 0.85);
+  }
+
   /* ===================================================================
      Video variant — video background, gradient to --bg
      =================================================================== */

--- a/src/components/MenuSection.astro
+++ b/src/components/MenuSection.astro
@@ -5,11 +5,34 @@ import OptimizedImg from './OptimizedImg.astro';
 const categories = menu?.categories || [];
 const hasMenu = categories.length > 0 && categories.some((c) => c.items?.length > 0);
 const orderUrl = client.orderUrl || '';
+
+// Section copy overrides. `menu.json` is `.loose()`, so these keys ride along
+// without a schema change. "Menu" is only the right heading for food service —
+// a class studio pricing its sessions, a salon listing its services, or a gym
+// listing memberships all need their own word. Same for the trailing CTA:
+// restaurants send people to an ordering page, everyone else has some other
+// single next step (book, register, sign a waiver).
+const overrides = menu as unknown as {
+  heading?: string;
+  eyebrow?: string;
+  note?: string;
+  cta?: { text?: string; href?: string; note?: string };
+} | undefined;
+const heading = overrides?.heading || 'Menu';
+const eyebrow = overrides?.eyebrow || '';
+const note = overrides?.note || '';
+const ctaText = overrides?.cta?.text || (orderUrl ? 'Order Online' : '');
+const ctaHref = overrides?.cta?.href || orderUrl;
+const ctaNote = overrides?.cta?.note
+  ?? (orderUrl && !overrides?.cta ? 'Full menu and online ordering available' : '');
 ---
 {hasMenu && (
   <section class="menu-section section" id="menu">
     <div class="container">
-      <h2 class="section-heading">Menu</h2>
+      <div class="menu-heading-block">
+        {eyebrow && <span class="section-eyebrow">{eyebrow}</span>}
+        <h2 class="section-heading">{heading}</h2>
+      </div>
 
       <nav class="menu-nav" aria-label="Menu categories">
         {categories.map((cat, i) => (
@@ -21,7 +44,12 @@ const orderUrl = client.orderUrl || '';
 
       {categories.map((cat, i) => (
         <div class="menu-category" id={`menu-cat-${i}`}>
-          <h3 class="menu-category-name">{cat.name}</h3>
+          <div class="menu-category-head">
+            <h3 class="menu-category-name">{cat.name}</h3>
+            {(cat as { description?: string }).description && (
+              <p class="menu-category-desc">{(cat as { description?: string }).description}</p>
+            )}
+          </div>
           <div class="menu-items">
             {cat.items.map((item) => (
               <div class={`menu-item ${item.featured ? 'menu-item--featured' : ''}`}>
@@ -54,12 +82,14 @@ const orderUrl = client.orderUrl || '';
         </div>
       ))}
 
-      {orderUrl && (
+      {note && <p class="menu-note">{note}</p>}
+
+      {ctaText && ctaHref && (
         <div class="menu-order-cta">
-          <a href={orderUrl} class="btn-primary" target="_blank" rel="noopener">
-            Order Online
+          <a href={ctaHref} class="btn-primary" target="_blank" rel="noopener">
+            {ctaText}
           </a>
-          <p class="menu-order-note">Full menu and online ordering available</p>
+          {ctaNote && <p class="menu-order-note">{ctaNote}</p>}
         </div>
       )}
     </div>
@@ -71,6 +101,42 @@ const orderUrl = client.orderUrl || '';
 
   .menu-section {
     background: var(--background);
+  }
+
+  .menu-heading-block {
+    text-align: center;
+  }
+
+  /* The rule under a category belongs below the whole head block, not between
+     the name and its qualifier — so move it off .menu-category-name. */
+  .menu-category-head {
+    border-bottom: 2px solid var(--border);
+    margin-bottom: var(--gap-md, 1.5rem);
+  }
+
+  .menu-category-head .menu-category-name {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+
+  /* Qualifier under a category name — ages, hours, who it's for. */
+  .menu-category-desc {
+    color: var(--textMuted, var(--text));
+    font-size: var(--small-size, 0.875rem);
+    line-height: var(--line-height-body, 1.6);
+    margin-top: var(--gap-xs, 0.25rem);
+    padding-bottom: var(--gap-sm, 0.5rem);
+  }
+
+  /* Fine print under the price list — cancellation terms, class caps, etc. */
+  .menu-note {
+    max-width: 640px;
+    margin: var(--gap-lg, 2rem) auto 0;
+    text-align: center;
+    color: var(--textMuted, var(--text));
+    font-size: var(--small-size, 0.875rem);
+    line-height: var(--line-height-body, 1.6);
   }
 
   /* ── Sticky pill nav ──────────────────────────────────────────────── */

--- a/src/components/ProcessSteps.astro
+++ b/src/components/ProcessSteps.astro
@@ -111,23 +111,34 @@ const steps = normalizedSteps;
 
   /* ── Process grid ──────────────────────────────────────────────── */
 
+  /* Flex (not grid) so a step count that doesn't fill the row centers the
+     remainder instead of leaving a ragged gap on the right. A 3-step process
+     on desktop lays out as three centered quarters; a 5-step process wraps the
+     orphan to a centered second row. Grid's implicit columns can't do this —
+     `justify-content: center` on a fixed 4-column track list still leaves the
+     empty 4th column occupying space. */
   .process-grid {
-    display: grid;
-    grid-template-columns: 1fr;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     gap: 0;
     max-width: 1100px;
     margin: 0 auto;
   }
 
+  .process-step {
+    flex: 0 1 100%;
+  }
+
   @media (min-width: 640px) {
-    .process-grid {
-      grid-template-columns: repeat(2, 1fr);
+    .process-step {
+      flex: 0 1 50%;
     }
   }
 
   @media (min-width: 1024px) {
-    .process-grid {
-      grid-template-columns: repeat(4, 1fr);
+    .process-step {
+      flex: 0 1 25%;
     }
   }
 

--- a/src/components/ServiceCards.astro
+++ b/src/components/ServiceCards.astro
@@ -3,6 +3,7 @@
 // v4 upgrade: data-tilt cards, gradient overlay on hover, mobile carousel,
 // GSAP reveal-up + stagger-parent, 4 variants (cards/icon-grid/compact/split).
 import OptimizedImg from './OptimizedImg.astro';
+import { theme } from '../lib/data';
 
 interface Props { variant?: string | number; }
 const { variant: variantProp } = Astro.props;
@@ -22,6 +23,16 @@ if (services.length === 0) {
   else if (svcData) services = (svcData as any).items || [];
 }
 
+// Section copy override. "Our Services" is wrong for plenty of businesses that
+// still need service cards — a class studio runs programs, a clinic runs
+// treatments, a venue runs packages. theme.sectionCopy keeps the override with
+// the rest of the per-site layout decisions rather than inventing a
+// services.json just to carry two strings.
+const sectionCopy = (theme as { sectionCopy?: Record<string, { heading?: string; eyebrow?: string }> })
+  .sectionCopy?.services;
+const heading = sectionCopy?.heading || 'Our Services';
+const eyebrow = sectionCopy?.eyebrow ?? 'What We Do';
+
 const MAX_FEATURED = 6;
 const featured = services.filter((s: any) => s.beforeImage || s.image).slice(0, MAX_FEATURED);
 const secondary = services.filter((s: any) => !featured.includes(s));
@@ -34,8 +45,8 @@ const splitRemaining = featured.length > 0
   <section class="services-section section" data-variant={variant} id="services" data-tour="services">
     <div class="container">
       <div class="section-heading reveal-up">
-        <span class="section-eyebrow">What We Do</span>
-        <h2 class="section-title">Our Services</h2>
+        {eyebrow && <span class="section-eyebrow">{eyebrow}</span>}
+        <h2 class="section-title">{heading}</h2>
       </div>
 
       {variant === 'cards' && (

--- a/src/components/StickyHeader.astro
+++ b/src/components/StickyHeader.astro
@@ -14,6 +14,10 @@ interface Props {
 const { navLinks, ctaText, ctaHref } = Astro.props;
 const logoUrl = client.logoUrl || '';
 const logoSize = theme.layout?.logoSize || 'md';
+// When the logo asset IS the wordmark, rendering BrandName next to it prints
+// the business name twice. Opt out with theme.layout.logoOnly. Default stays
+// false so sites whose logo is a bare mark keep the name beside it.
+const logoOnly = logoUrl ? (theme.layout as { logoOnly?: boolean } | undefined)?.logoOnly === true : false;
 ---
 <header class="site-header" id="site-header" data-logo-size={logoSize}>
   <div class="header-inner">
@@ -28,7 +32,7 @@ const logoSize = theme.layout?.logoSize || 'md';
           loading="eager"
         />
       )}
-      <BrandName size="header" />
+      {!logoOnly && <BrandName size="header" />}
     </a>
 
     <nav class="header-nav" aria-label="Main navigation">

--- a/src/data/_template-manifest.json
+++ b/src/data/_template-manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "4.0.9",
-  "description": "Template capability manifest \u2014 agent skills read this to validate their output stays within what the template can render.",
+  "version": "4.0.12",
+  "description": "Template capability manifest — agent skills read this to validate their output stays within what the template can render.",
   "capabilities": {
     "heroStyles": [
       "split",
@@ -91,6 +91,9 @@
       "border",
       "underline",
       "tint"
+    ],
+    "layoutBooleans": [
+      "logoOnly"
     ],
     "sectionIds": [
       "hero",

--- a/src/lib/brand.ts
+++ b/src/lib/brand.ts
@@ -334,7 +334,14 @@ export function generateLayoutCSS(layout?: Record<string, string>): string {
     vars.push(`  --hover-shadow: ${HOVER_SHADOW_MAP[layout.hoverIntensity]};`);
   }
 
-  return vars.length > 0 ? `:root {\n${vars.join('\n')}\n}` : '';
+  // `:root:root` (specificity 0,2,0), not `:root`. Astro emits the bundled
+  // stylesheet <link> AFTER this inline <style>, so an equal-specificity
+  // `:root` block loses the cascade to the `:root` defaults in tokens.css and
+  // every token that has a default there silently does nothing. That was
+  // cardRadius, buttonStyle, imageStyle, shadowStyle and overlayDarkness —
+  // five of the layout knobs theme.json exposes, all inert. Doubling the
+  // pseudo-class wins on specificity instead of relying on source order.
+  return vars.length > 0 ? `:root:root {\n${vars.join('\n')}\n}` : '';
 }
 
 // buildFontURL() removed — replaced by self-hosted fonts in src/lib/fonts.ts

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -127,6 +127,9 @@ export const layoutTokensSchema = z.object({
   buttonVariant: enumOr(['solid', 'ghost', 'tactile']).optional(),
   dividerStyle: enumOr(['line', 'glow', 'fade', 'none']).optional(),
   logoSize: enumOr(['sm', 'md', 'lg']).optional(),
+  /** true = the logo asset already spells the business name, so the header
+   *  suppresses the BrandName text beside it. Ignored when logoUrl is unset. */
+  logoOnly: z.boolean().optional(),
   shadowStyle: enumOr(['subtle', 'standard', 'dramatic']).optional(),
   hoverIntensity: enumOr(['none', 'subtle', 'standard']).optional(),
   gradientStyle: enumOr(['none', 'subtle', 'accent-tint']).optional(),
@@ -163,6 +166,12 @@ export const themeSchema = z.object({
   cta: ctaOverrideSchema.optional(),
   heroCta: ctaOverrideSchema.optional(),
   actionBar: actionBarSchema.optional(),
+  /** Per-section heading/eyebrow overrides, keyed by section id. Lets a site
+   *  rename a section whose component hard-codes its own copy. */
+  sectionCopy: z.record(z.string(), z.object({
+    heading: z.string().optional(),
+    eyebrow: z.string().optional(),
+  }).loose()).optional(),
 }).loose();
 
 // ---------------------------------------------------------------------------
@@ -308,11 +317,27 @@ export const menuItemSchema = z.object({
 
 export const menuCategorySchema = z.object({
   name: z.string(),
+  /** Qualifier rendered under the category name (ages, hours, who it's for).
+   *  Keeps `name` short enough for the category pill nav. */
+  description: z.string().optional(),
   items: z.array(menuItemSchema),
+}).loose();
+
+/** Optional section-copy overrides so non-restaurant sites can use the price
+ *  list without the word "Menu". All optional — omitting them keeps the
+ *  restaurant defaults ("Menu" heading, `client.orderUrl` → "Order Online"). */
+export const menuCtaSchema = z.object({
+  text: z.string().optional(),
+  href: z.string().optional(),
+  note: z.string().optional(),
 }).loose();
 
 export const menuSchema = z.object({
   categories: z.array(menuCategorySchema),
+  heading: z.string().optional(),
+  eyebrow: z.string().optional(),
+  note: z.string().optional(),
+  cta: menuCtaSchema.optional(),
 }).loose();
 
 // ---------------------------------------------------------------------------

--- a/tests/visual/fixtures/_base/_template-manifest.json
+++ b/tests/visual/fixtures/_base/_template-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.9",
+  "version": "4.0.12",
   "description": "Template capability manifest — agent skills read this to validate their output stays within what the template can render.",
   "capabilities": {
     "heroStyles": ["split", "overlay", "video", "minimal"],


### PR DESCRIPTION
Surfaced while hand-rebuilding the Bounce n' Boogie site (an early-childhood music and movement studio). Each item is something the template could not express, or expressed wrongly.

## The cascade bug is the important one

`generateLayoutCSS()` emitted a `:root` block into an inline `<style>`. Astro places the bundled stylesheet `<link>` **after** that inline style, so at equal specificity the `:root` defaults in `tokens.css` always won. Every layout token that also has a default there was silently inert:

| token | theme.json said | page actually used |
|---|---|---|
| `cardRadius: round` | `0.75rem` | `0.5rem` |
| `buttonStyle: pill` | `2rem` | `0.25rem` |
| `imageStyle: rounded` | `0.75rem` | `0.25rem` |
| `shadowStyle` | mapped value | tokens.css default |
| `overlayDarkness: heavy` | `0.7` | `0.5` |

The data-attribute path `tokens.css` offers as the alternative (`[data-card-radius="round"]`) is dead too — `BaseLayout` never sets those attributes. So both documented override routes were broken.

Fix is `:root:root` (specificity 0,2,0), which wins on specificity rather than depending on source order.

## Everything else

- **`MenuSection`** takes `heading` / `eyebrow` / `note` / `cta` / per-category `description` from `menu.json`. "Menu" and "Order Online" are only right for food service. Category names feed the pill nav, so the qualifier that used to be crammed into the name ("ActiveME Camps · ages 16 months to 5 years, drop-off, 8:30 to 12:30" — which overflowed the nav) now has its own field.
- **`ProcessSteps`** uses flex instead of `repeat(4, 1fr)`. A 3-step process now centers instead of leaving an empty fourth column. A 5-step process wraps its orphan to a centered second row.
- **`ServiceCards`** reads `theme.sectionCopy.services` for heading and eyebrow. "Our Services" is wrong for a business that runs classes.
- **`theme.layout.logoOnly`** suppresses `BrandName` beside the header logo, for logos that already spell the name. Defaults false.
- **`Hero`** re-colors `.btn--ghost` on the `overlay` and `video` variants. It was the only element still inheriting the dark page `--text` over a photo backdrop; every other overlay element already had a light-on-dark rule.

## Compatibility

All new fields are optional and all defaults preserve current behavior. `menu.json` and `theme.json` are already `.loose()`, so no data-contract break. The one intentional visual change for existing sites is the cascade fix — sites whose `theme.json` sets `cardRadius`/`buttonStyle`/`imageStyle`/`shadowStyle`/`overlayDarkness` will now render what they asked for instead of the tokens.css default.

## Test plan

- `npx vitest run` — 254 passing, up from 251. New files: `layout-css-specificity.test.ts` (pins the `:root:root` selector per affected token, and asserts the tokens.css collision it guards against is real), `menu-overrides.test.ts`, `layout-logo-only.test.ts`.
- Built and visually verified at 1440x1000 and 390x844 against the Bounce n' Boogie data set: pill buttons and rounded cards now apply, 3-step process centers, pricing section renders as "Classes & Pricing" with category subtitles and a "Sign the Waiver" CTA, header shows the logo without a duplicate wordmark, ghost hero button legible over the photo.

Version bumped to 4.0.12 with both manifests synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)